### PR TITLE
feat(build): Phase 4 polish - cross-compilation and Homebrew improvements

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,28 @@
+# Cross-compilation configuration for Agent Session Recorder
+#
+# To cross-compile, you need:
+# 1. Install the target: rustup target add <target-triple>
+# 2. Install the appropriate linker (see below)
+# 3. Build: cargo build --release --target <target-triple>
+#
+# Linux targets require cross-compilation toolchains:
+#   macOS: brew install FiloSottile/musl-cross/musl-cross
+#   Ubuntu: apt install gcc-x86-64-linux-gnu gcc-aarch64-linux-gnu
+
+# Linux x86_64 (most servers and desktops)
+[target.x86_64-unknown-linux-gnu]
+linker = "x86_64-linux-gnu-gcc"
+
+# Linux ARM64 (AWS Graviton, Raspberry Pi 4, etc.)
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+# Linux x86_64 with musl (fully static binary)
+[target.x86_64-unknown-linux-musl]
+linker = "x86_64-linux-musl-gcc"
+
+# macOS x86_64 (Intel Macs)
+[target.x86_64-apple-darwin]
+
+# macOS ARM64 (Apple Silicon)
+[target.aarch64-apple-darwin]

--- a/Formula/asr.rb
+++ b/Formula/asr.rb
@@ -37,6 +37,12 @@ class Asr < Formula
 
   def install
     bin.install "asr"
+
+    # Install shell integration script
+    (share/"asr").install "shell/asr.sh" if File.exist?("shell/asr.sh")
+
+    # Install agent skills (for AI assistants)
+    (share/"asr/skills").install Dir["agents/*.md"] if Dir.exist?("agents")
   end
 
   def post_install
@@ -54,6 +60,8 @@ class Asr < Formula
 
       Default session directory: ~/recorded_agent_sessions/
       Config file: ~/.config/asr/config.toml
+
+      AI Agent Skills installed to: #{opt_share}/asr/skills/
     EOS
   end
 

--- a/README.md
+++ b/README.md
@@ -103,16 +103,54 @@ Marker events use type `"m"` with the label as data.
 ### Building
 
 ```bash
-# Build with Docker (runs tests)
+# Build with Docker (produces Linux binary, runs tests)
 ./build.sh
+# Output: dist/asr (Linux x86_64 binary)
 
-# Output binary: dist/asr
+# Build locally (native binary)
+cargo build --release
+# Output: target/release/asr
+```
+
+### Cross-Compilation
+
+The project includes `.cargo/config.toml` with cross-compilation targets.
+
+**Install targets:**
+```bash
+# macOS targets
+rustup target add x86_64-apple-darwin
+rustup target add aarch64-apple-darwin
+
+# Linux targets (requires cross-compiler toolchain)
+rustup target add x86_64-unknown-linux-gnu
+rustup target add aarch64-unknown-linux-gnu
+rustup target add x86_64-unknown-linux-musl
+```
+
+**Build for target:**
+```bash
+cargo build --release --target aarch64-apple-darwin
+cargo build --release --target x86_64-unknown-linux-gnu
+```
+
+**Linux cross-compilation from macOS:**
+```bash
+# Install musl cross-compiler
+brew install FiloSottile/musl-cross/musl-cross
+
+# Build static Linux binary
+cargo build --release --target x86_64-unknown-linux-musl
 ```
 
 ### Testing
 
 ```bash
+# Unit tests
 cargo test
+
+# E2E tests (requires asciinema installed)
+./tests/e2e_test.sh
 ```
 
 ### Project Structure


### PR DESCRIPTION
## Summary
- Add `.cargo/config.toml` with cross-compilation targets for Linux (x86_64, aarch64, musl) and macOS (x86_64, aarch64)
- Update `Formula/asr.rb` to install shell integration script and agent skills
- Expand README with comprehensive cross-compilation instructions and testing documentation

## Changes
1. **Cross-compilation config** (`.cargo/config.toml`):
   - Linux x86_64 and aarch64 with gnu linkers
   - Linux x86_64 with musl for static binaries
   - macOS Intel and Apple Silicon

2. **Homebrew formula improvements** (`Formula/asr.rb`):
   - Install shell integration script (`shell/asr.sh`)
   - Install agent skills (`agents/*.md`)
   - Updated caveats to reference skills location

3. **README documentation**:
   - Expanded build instructions
   - Cross-compilation guide with target installation
   - musl cross-compilation from macOS

## Test plan
- [x] Verified Docker build works (`./build.sh` produces Linux binary)
- [x] All 80 unit tests pass (`cargo test`)
- [x] All 15 E2E tests pass (`./tests/e2e_test.sh`)

---
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shell integration script now included in installation package
  * Agent skill markdown files automatically installed to the designated skills directory during setup

* **Chores**
  * Cross-compilation configuration added for multiple target platforms
  * Installation messaging updated to reflect newly included components

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->