### PR TITLE
feat(skills): add CLI commands for skill management

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -103,27 +103,10 @@ if [ -n "$SHELL_RC" ]; then
     fi
 fi
 
-# Setup agent skills (symlinks)
-setup_skill() {
-    local skill_dir="$1"
-    local skill_name="$2"
-    local skill_source="$(pwd)/agents/$skill_name"
-
-    if [ -f "$skill_source" ]; then
-        mkdir -p "$skill_dir"
-        ln -sf "$skill_source" "$skill_dir/$skill_name"
-        echo "  Linked: $skill_dir/$skill_name"
-    fi
-}
-
+# Install skills
 echo
-echo "Setting up agent skills..."
-setup_skill "$HOME/.claude/commands" "asr-analyze.md"
-setup_skill "$HOME/.claude/commands" "asr-review.md"
-setup_skill "$HOME/.codex/commands" "asr-analyze.md"
-setup_skill "$HOME/.codex/commands" "asr-review.md"
-setup_skill "$HOME/.gemini/commands" "asr-analyze.md"
-setup_skill "$HOME/.gemini/commands" "asr-review.md"
+echo "Installing skills..."
+"$INSTALL_DIR/asr" skills install
 
 # Verify installation
 echo

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod asciicast;
 pub mod config;
 pub mod markers;
 pub mod recording;
+pub mod skills;
 pub mod storage;
 
 pub use asciicast::{AsciicastFile, Event, EventType, Header};

--- a/src/skills.rs
+++ b/src/skills.rs
@@ -1,0 +1,168 @@
+//! Embedded AI agent skills
+//!
+//! This module provides skills that can be installed to various AI agent
+//! command directories (Claude, Codex, Gemini) for use during sessions.
+
+use std::path::PathBuf;
+
+/// Embedded skill: asr-analyze.md
+pub const SKILL_ANALYZE: &str = include_str!("../agents/asr-analyze.md");
+
+/// Embedded skill: asr-review.md
+pub const SKILL_REVIEW: &str = include_str!("../agents/asr-review.md");
+
+/// All available skills as (filename, content) pairs
+pub const SKILLS: &[(&str, &str)] = &[
+    ("asr-analyze.md", SKILL_ANALYZE),
+    ("asr-review.md", SKILL_REVIEW),
+];
+
+/// Get skill directories for different AI agents
+pub fn skill_directories() -> Vec<PathBuf> {
+    let home = dirs::home_dir().unwrap_or_default();
+    vec![
+        home.join(".claude/commands"),
+        home.join(".codex/commands"),
+        home.join(".gemini/commands"),
+    ]
+}
+
+/// Information about an installed skill
+#[derive(Debug, Clone)]
+pub struct InstalledSkill {
+    /// Skill filename
+    pub name: String,
+    /// Path where installed
+    pub path: PathBuf,
+    /// Whether the installed content matches the embedded version
+    pub matches_embedded: bool,
+}
+
+/// List installed skills across all agent directories
+pub fn list_installed_skills() -> Vec<InstalledSkill> {
+    let mut installed = Vec::new();
+
+    for dir in skill_directories() {
+        for (name, embedded_content) in SKILLS {
+            let skill_path = dir.join(name);
+            if skill_path.exists() {
+                let matches = std::fs::read_to_string(&skill_path)
+                    .map(|content| content == *embedded_content)
+                    .unwrap_or(false);
+
+                installed.push(InstalledSkill {
+                    name: name.to_string(),
+                    path: skill_path,
+                    matches_embedded: matches,
+                });
+            }
+        }
+    }
+
+    installed
+}
+
+/// Install skills to all agent command directories
+/// Returns a list of paths where skills were installed
+pub fn install_skills() -> std::io::Result<Vec<PathBuf>> {
+    let mut installed = Vec::new();
+
+    for dir in skill_directories() {
+        // Create directory if it doesn't exist
+        std::fs::create_dir_all(&dir)?;
+
+        for (name, content) in SKILLS {
+            let skill_path = dir.join(name);
+            std::fs::write(&skill_path, content)?;
+            installed.push(skill_path);
+        }
+    }
+
+    Ok(installed)
+}
+
+/// Uninstall asr skills from all agent command directories
+/// Returns a list of paths where skills were removed
+pub fn uninstall_skills() -> std::io::Result<Vec<PathBuf>> {
+    let mut removed = Vec::new();
+
+    for dir in skill_directories() {
+        for (name, _) in SKILLS {
+            let skill_path = dir.join(name);
+            if skill_path.exists() {
+                // Check if it's a symlink or regular file - remove either way
+                std::fs::remove_file(&skill_path)?;
+                removed.push(skill_path);
+            }
+        }
+    }
+
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_skills_are_embedded() {
+        // Verify skills are not empty
+        assert!(!SKILL_ANALYZE.is_empty());
+        assert!(!SKILL_REVIEW.is_empty());
+
+        // Verify skills contain expected content
+        assert!(SKILL_ANALYZE.contains("asr-analyze"));
+        assert!(SKILL_REVIEW.contains("asr-review"));
+    }
+
+    #[test]
+    fn test_skills_array() {
+        assert_eq!(SKILLS.len(), 2);
+        assert_eq!(SKILLS[0].0, "asr-analyze.md");
+        assert_eq!(SKILLS[1].0, "asr-review.md");
+    }
+
+    #[test]
+    fn test_skill_directories_returns_paths() {
+        let dirs = skill_directories();
+        assert_eq!(dirs.len(), 3);
+
+        // All should be under home directory
+        let home = dirs::home_dir().unwrap();
+        for dir in &dirs {
+            assert!(dir.starts_with(&home));
+        }
+    }
+
+    #[test]
+    fn test_install_and_uninstall_skills() -> std::io::Result<()> {
+        // Create a temp directory to simulate home
+        let temp = TempDir::new()?;
+        let temp_path = temp.path();
+
+        // Create test skill directories
+        let claude_dir = temp_path.join(".claude/commands");
+        let codex_dir = temp_path.join(".codex/commands");
+
+        std::fs::create_dir_all(&claude_dir)?;
+        std::fs::create_dir_all(&codex_dir)?;
+
+        // Write a skill file
+        let skill_path = claude_dir.join("asr-analyze.md");
+        std::fs::write(&skill_path, SKILL_ANALYZE)?;
+
+        // Verify it exists
+        assert!(skill_path.exists());
+
+        // Read back and verify content
+        let content = std::fs::read_to_string(&skill_path)?;
+        assert_eq!(content, SKILL_ANALYZE);
+
+        // Clean up by removing
+        std::fs::remove_file(&skill_path)?;
+        assert!(!skill_path.exists());
+
+        Ok(())
+    }
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -39,23 +39,23 @@ if [ -d "$SESSION_DIR" ]; then
     fi
 fi
 
-# Remove skill symlinks
-remove_skill() {
-    local skill_path="$1"
-    if [ -L "$skill_path" ]; then
-        rm "$skill_path"
-        echo "Removed skill: $skill_path"
-    fi
-}
-
+# Remove skills
 echo
-echo "Removing agent skills..."
-remove_skill "$HOME/.claude/commands/asr-analyze.md"
-remove_skill "$HOME/.claude/commands/asr-review.md"
-remove_skill "$HOME/.codex/commands/asr-analyze.md"
-remove_skill "$HOME/.codex/commands/asr-review.md"
-remove_skill "$HOME/.gemini/commands/asr-analyze.md"
-remove_skill "$HOME/.gemini/commands/asr-review.md"
+echo "Removing skills..."
+if command -v asr &>/dev/null; then
+    asr skills uninstall
+else
+    # Fallback: manually remove skill files if asr is not available
+    echo "asr not found in PATH, removing skills manually..."
+    for dir in "$HOME/.claude/commands" "$HOME/.codex/commands" "$HOME/.gemini/commands"; do
+        for skill in "asr-analyze.md" "asr-review.md"; do
+            if [ -f "$dir/$skill" ] || [ -L "$dir/$skill" ]; then
+                rm "$dir/$skill"
+                echo "  Removed: $dir/$skill"
+            fi
+        done
+    done
+fi
 
 # Note about shell integration
 echo


### PR DESCRIPTION
## Summary

- Embed AI agent skills directly in the binary using `include_str!()` macro
- Add `asr skills list` command to show installed skills and their status
- Add `asr skills install` command to copy embedded skills to agent command directories
- Add `asr skills uninstall` command to remove skills from agent directories
- Update install.sh to use `asr skills install` instead of symlinks
- Update uninstall.sh to use `asr skills uninstall` with fallback for manual removal

## Test plan

- [x] `cargo test` passes (87 tests)
- [x] `./tests/e2e_test.sh` passes (15 tests)
- [x] Manual testing of `asr skills list/install/uninstall` commands
- [x] Verify skills are embedded correctly with `include_str!()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new CLI commands for agent skill management: `list` to view installed skills, `install` to add skills, and `uninstall` to remove skills.
  * Simplified skill setup workflow during installation with streamlined messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->