### PR TITLE
fix: shell wrapper word-splitting and non-interactive prompt handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ toml = "0.8"
 chrono = "0.4"
 anyhow = "1.0"
 thiserror = "1.0"
+atty = "0.2"
 
 [dev-dependencies]
 tempfile = "3.10"

--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -173,6 +173,17 @@ else
     fail "Second recording not created"
 fi
 
+# Test 11b: Record with --name flag (skips rename prompt)
+echo "--- Test 11b: Record with --name flag ---"
+$AGR record echo --name "my-custom-session" -- "test with name flag" </dev/null
+NAMED_CAST="$HOME/recorded_agent_sessions/echo/my-custom-session.cast"
+if [ -f "$NAMED_CAST" ]; then
+    pass "Recording with --name flag created correct filename"
+else
+    fail "Recording with --name flag did not create expected file"
+    ls "$HOME/recorded_agent_sessions/echo/"
+fi
+
 # Test 12: List filter by agent
 echo "--- Test 12: List filter by agent ---"
 ECHO_LIST=$($AGR list echo)
@@ -186,7 +197,7 @@ fi
 # Test 13: Status shows multiple agents
 echo "--- Test 13: Status with multiple agents ---"
 STATUS=$($AGR status)
-if echo "$STATUS" | /usr/bin/grep -q "2 total" && echo "$STATUS" | /usr/bin/grep -q "echo:" && echo "$STATUS" | /usr/bin/grep -q "ls:"; then
+if echo "$STATUS" | /usr/bin/grep -q "3 total" && echo "$STATUS" | /usr/bin/grep -q "echo:" && echo "$STATUS" | /usr/bin/grep -q "ls:"; then
     pass "Status shows both agents"
 else
     fail "Status not showing both agents: $STATUS"


### PR DESCRIPTION
## Summary

- Fix shell wrapper `_agr_setup_wrappers()` to use `while read` loop instead of `for` loop to avoid word-splitting issues when parsing agent names
- Add agent name validation (alphanumeric, dash, underscore only) to prevent shell injection
- Add `atty` crate for TTY detection in rename prompt
- Skip rename prompt gracefully when stdin is not a TTY (non-interactive sessions)
- Add `--name/-n` flag to `agr record` command to specify filename upfront and skip the rename prompt

## Test plan

- [x] All 77 unit tests pass (`cargo test`)
- [x] All 41 E2E tests pass (`./tests/e2e_test.sh`)
- [x] `cargo fmt` - code is formatted
- [x] `cargo clippy` - no warnings
- [x] New E2E test for `--name` flag verifies correct filename creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--name` flag to specify custom session names when recording, bypassing the rename prompt.
  * Improved non-interactive mode handling (CI/pipelines) to skip prompts when a session name is provided.

* **Tests**
  * Added comprehensive tests for custom session naming functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->