### PR TITLE
feat(ci): add test coverage with Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,41 @@ jobs:
       - name: Run unit tests
         run: cargo test --verbose
 
-  # 3. E2E Tests - verify integration (macOS only for asciinema v3)
+  # 3. Coverage - generate test coverage and upload to Codecov
+  coverage:
+    name: Coverage
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Generate coverage
+        run: cargo tarpaulin --out xml --output-dir coverage
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage/cobertura.xml
+          fail_ci_if_error: true
+
+  # 4. E2E Tests - verify integration (macOS only for asciinema v3)
   e2e-tests:
     name: E2E Tests
     needs: unit-tests
@@ -126,7 +160,7 @@ jobs:
   # Release artifacts - only on main push, after all checks pass
   release:
     name: Release (${{ matrix.artifact }})
-    needs: [build, unit-tests, e2e-tests, lint]
+    needs: [build, unit-tests, coverage, e2e-tests, lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ${{ matrix.os }}
     strategy:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Agent Session Recorder (AGR)
 
-[![CI](https://github.com/thiscantbeserious/agent-session-record/actions/workflows/ci.yml/badge.svg)](https://github.com/thiscantbeserious/agent-session-record/actions/workflows/ci.yml)
+[![CI](https://github.com/thiscantbeserious/agent-session-recorder/actions/workflows/ci.yml/badge.svg)](https://github.com/thiscantbeserious/agent-session-recorder/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/thiscantbeserious/agent-session-recorder/graph/badge.svg)](https://codecov.io/gh/thiscantbeserious/agent-session-recorder)
 [![Rust](https://img.shields.io/badge/Rust-1.75+-orange?logo=rust)](https://www.rust-lang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![asciinema](https://img.shields.io/badge/powered%20by-asciinema-d40000)](https://asciinema.org/)


### PR DESCRIPTION
## Summary
- Add coverage job to CI workflow using `cargo-tarpaulin`
- Upload coverage reports to Codecov after each build
- Add Codecov badge to README
- Fix CI badge URL to use correct repo name

## Test plan
- [ ] CI coverage job runs successfully
- [ ] Coverage report uploads to Codecov
- [ ] Codecov badge displays in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline with automated code coverage reporting and analysis
  * Extended release process to explicitly support multiple operating systems and architectures (Linux x86_64, macOS x86_64, macOS ARM64)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->