### PR TITLE
fix(ci): add CODECOV_TOKEN to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,10 @@ jobs:
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/cobertura.xml
+          flags: unittests
+          name: codecov-umbrella
           fail_ci_if_error: true
 
   # 4. E2E Tests - verify integration (macOS only for asciinema v3)


### PR DESCRIPTION
## Summary
- Add `token: ${{ secrets.CODECOV_TOKEN }}` for authenticated uploads to Codecov
- Add `flags: unittests` to categorize coverage data
- Add `name: codecov-umbrella` to identify this upload

## Context
The codecov-action v5 requires a token for authenticated uploads. The secret has already been added to the repository settings.

## Test plan
- [ ] CI workflow runs successfully
- [ ] Coverage uploads to Codecov without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure improvements with no user-facing changes.

* **Chores**
  * Enhanced CI/CD pipeline configuration for improved code coverage tracking and workflow management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->