### PR TITLE
fix(install): add codesign step for macOS security

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -68,6 +68,13 @@ INSTALL_DIR="$HOME/.local/bin"
 mkdir -p "$INSTALL_DIR"
 cp dist/agr "$INSTALL_DIR/agr"
 chmod +x "$INSTALL_DIR/agr"
+
+# On macOS, re-sign the binary to avoid security issues
+if [ "$OS" = "Darwin" ]; then
+    echo "Signing binary for macOS..."
+    codesign -s - -f "$INSTALL_DIR/agr" 2>/dev/null || true
+fi
+
 echo
 echo "Installed binary to: $INSTALL_DIR/agr"
 


### PR DESCRIPTION
## Summary

macOS security can kill unsigned binaries in user directories like `~/.local/bin/`. This adds a codesign step after install to re-sign the binary with an ad-hoc signature.

## Problem

After copying the binary to `~/.local/bin/`, running `agr` would result in:
```
zsh: killed     agr
```

The binary worked fine from `./target/release/agr` and `/tmp/agr`, but was being killed by macOS security from `~/.local/bin/`.

## Solution

Add `codesign -s - -f` after copying the binary on macOS:
```bash
if [ "$OS" = "Darwin" ]; then
    codesign -s - -f "$INSTALL_DIR/agr" 2>/dev/null || true
fi
```

## Test plan

- [x] Verified `codesign -s - -f` fixes the issue locally
- [x] Binary runs successfully after re-signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS installation process to include proper code signing of the installed binary, ensuring the application runs correctly on macOS systems.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->