### PR TITLE
feat(list): add smart age format and datetime column

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -663,8 +663,10 @@ fn cmd_cleanup(agent_filter: Option<&str>, older_than: Option<u32>) -> Result<()
     println!();
 
     // Print formatted table header
-    println!("  #  | Age   | Agent       | Size       | Filename");
-    println!("-----+-------+-------------+------------+---------------------------");
+    println!("  #  |  Age   | DateTime         | Agent       | Size       | Filename");
+    println!(
+        "-----+--------+------------------+-------------+------------+---------------------------"
+    );
 
     // Display up to 15 sessions in a formatted table
     for (i, session) in sessions.iter().take(15).enumerate() {
@@ -674,10 +676,11 @@ fn cmd_cleanup(agent_filter: Option<&str>, older_than: Option<u32>) -> Result<()
             " "
         };
         println!(
-            "{:>3}  | {:>3}d{} | {:11} | {:>10} | {}",
+            "{:>3}  | {:>5}{} | {} | {:11} | {:>10} | {}",
             i + 1,
-            session.age_days,
+            session.format_age(),
             age_marker,
+            session.modified.format("%Y-%m-%d %H:%M"),
             truncate_string(&session.agent, 11),
             session.size_human(),
             session.filename
@@ -833,15 +836,18 @@ fn cmd_list(agent: Option<&str>) -> Result<()> {
     println!();
 
     // Print table header
-    println!("  #  | Age  | Agent       | Size       | Filename");
-    println!("-----+------+-------------+------------+---------------------------");
+    println!("  #  |  Age  | DateTime         | Agent       | Size       | Filename");
+    println!(
+        "-----+-------+------------------+-------------+------------+---------------------------"
+    );
 
     // Display sessions in formatted table
     for (i, session) in sessions.iter().enumerate() {
         println!(
-            "{:>3}  | {:>3}d | {:11} | {:>10} | {}",
+            "{:>3}  | {:>5} | {} | {:11} | {:>10} | {}",
             i + 1,
-            session.age_days,
+            session.format_age(),
+            session.modified.format("%Y-%m-%d %H:%M"),
             truncate_string(&session.agent, 11),
             session.size_human(),
             session.filename


### PR DESCRIPTION
## Summary
- Add smart age display that shows the most relevant time unit:
  - `  45m` for recordings less than 1 hour old
  - `   5h` for same-day recordings (1+ hours)
  - `   3d` for older recordings
- Add DateTime column showing absolute timestamp (`2026-01-21 15:59`)
- Update both `agr list` and `agr cleanup` commands

## Example Output
```
  #  |  Age  | DateTime         | Agent       | Size       | Filename
-----+-------+------------------+-------------+------------+---------------------------
  1  |    0m | 2026-01-21 15:59 | claude      |   9.25 MiB | 20260121-150502-141.cast
  2  |   10m | 2026-01-21 15:49 | claude      |   3.29 KiB | 20260121-154903-157.cast
  3  |    1h | 2026-01-21 14:58 | claude      |  25.91 KiB | 20260121-145757-500.cast
```

## Test plan
- [x] All unit tests pass (112 tests)
- [x] All e2e tests pass (77 tests)
- [x] Manual verification of `agr list` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new DateTime column displaying when sessions were last modified.
  * Enhanced session age display with improved formatting that intelligently shows minutes, hours, or days based on elapsed time.

* **Tests**
  * Added unit tests validating age formatting and storage display functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->