### PR TITLE
fix: use cargo install in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,35 +44,17 @@ if ! command -v asciinema &>/dev/null; then
 fi
 echo "asciinema: $(command -v asciinema)"
 
-# Build binary
-echo
-echo "Building binary..."
-
-# Try native build first (if cargo available)
-if command -v cargo &>/dev/null; then
-    echo "Using native Rust build..."
-    cargo build --release
-    mkdir -p dist
-    cp target/release/agr dist/agr
-# Fallback to Docker for Linux binary
-elif command -v docker &>/dev/null; then
-    echo "Using Docker build (produces Linux binary)..."
-    ./build.sh
-else
-    echo "Error: Neither cargo nor docker found. Please install one of them."
-    exit 1
-fi
-
 # Install binary
-INSTALL_DIR="$HOME/.local/bin"
-mkdir -p "$INSTALL_DIR"
-cp dist/agr "$INSTALL_DIR/agr"
-chmod +x "$INSTALL_DIR/agr"
+echo
+echo "Installing binary..."
 
-# On macOS, re-sign the binary to avoid security issues
-if [ "$OS" = "Darwin" ]; then
-    echo "Signing binary for macOS..."
-    codesign -s - -f "$INSTALL_DIR/agr" 2>/dev/null || true
+if command -v cargo &>/dev/null; then
+    echo "Using cargo install..."
+    cargo install --path . --force
+    INSTALL_DIR="$HOME/.cargo/bin"
+else
+    echo "Error: cargo not found. Please install Rust: https://rustup.rs"
+    exit 1
 fi
 
 echo

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -4,8 +4,6 @@ set -e
 echo "=== Agent Session Recorder (AGR) Uninstaller ==="
 echo
 
-INSTALL_DIR="$HOME/.local/bin"
-
 # Remove shell integration (before binary removal so agr CLI can run)
 echo
 echo "Removing shell integration..."
@@ -16,26 +14,22 @@ else
     echo "agr not found in PATH, removing shell integration manually..."
     for rc in "$HOME/.zshrc" "$HOME/.bashrc"; do
         if [ -f "$rc" ]; then
-            # Check if AGR markers are present
             if grep -q ">>> AGR (Agent Session Recorder) >>>" "$rc" 2>/dev/null; then
-                # Remove the marked section using sed
                 sed -i.bak '/# >>> AGR (Agent Session Recorder) >>>/,/# <<< AGR (Agent Session Recorder) <<</d' "$rc"
                 rm -f "$rc.bak"
                 echo "  Removed shell integration from: $rc"
             fi
         fi
     done
-    # Note: Shell script is now embedded in RC files, no external file to remove
 fi
 
-# Remove binary (after CLI cleanup so agr commands can run)
+# Remove binary
 echo
 echo "Removing binary..."
-if [ -f "$INSTALL_DIR/agr" ]; then
-    rm "$INSTALL_DIR/agr"
-    echo "Removed binary: $INSTALL_DIR/agr"
+if command -v cargo &>/dev/null; then
+    cargo uninstall agr 2>/dev/null && echo "Removed agr via cargo" || echo "agr not installed via cargo"
 else
-    echo "Binary not found at: $INSTALL_DIR/agr"
+    echo "cargo not found, skipping binary removal"
 fi
 
 # Remove config directory (ask first)


### PR DESCRIPTION
## Summary

- Use `cargo install` instead of manual copy to `~/.local/bin`
- Avoids conflict when user has both `~/.cargo/bin` and `~/.local/bin` in PATH
- Requires Rust/cargo (removes Docker fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Installation process now uses Rust's cargo package manager for setup
  * Docker-based build fallback removed; installation requires cargo availability
  * Uninstallation simplified with integrated cargo uninstall command
  * Enhanced error messaging and installation status reporting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->