### PR TITLE
feat(roles): implement two-phase review workflow

### DIFF
--- a/.state/feature-two-phase-review-workflow/ADR.md
+++ b/.state/feature-two-phase-review-workflow/ADR.md
@@ -1,0 +1,128 @@
+# ADR: Two-Phase Review Workflow
+
+## Status
+
+Accepted
+
+## Context
+
+CodeRabbit, our external AI code review tool, triggers immediately when a PR is created. This creates an inefficient workflow where CodeRabbit analyzes code before any internal review has occurred. The problems include:
+
+1. **Wasted analysis cycles** - CodeRabbit feedback gets mixed with issues that internal review would catch (structural problems, ADR violations, scope creep)
+2. **Multiple review iterations** - Code that fails internal review requires additional CodeRabbit cycles after fixes
+3. **Resource inefficiency** - External review resources spent on code that isn't ready
+
+The current flow is:
+```
+Implementer -> Create PR -> CodeRabbit triggers -> Reviewer -> Fix issues -> More CodeRabbit cycles
+```
+
+The desired flow gates CodeRabbit behind internal review:
+```
+Implementer -> Draft PR -> Internal Review -> Fix issues -> Mark Ready -> CodeRabbit -> Address feedback -> Done
+```
+
+This ensures CodeRabbit only sees code that has passed internal validation for ADR compliance, test coverage, and scope adherence.
+
+## Options Considered
+
+### Option 1: Two Separate Reviewer Roles
+
+Create distinct `InternalReviewer` and `ExternalReviewer` roles with separate reference files.
+
+**Pros:**
+- Maximum clarity - each role has single responsibility
+- No conditional logic needed
+- Role selection is explicit
+
+**Cons:**
+- File duplication - much of the review process is identical
+- Maintenance burden - updates needed in two places
+- Complexity - more roles to coordinate
+
+### Option 2: Unified Reviewer with Internal Sections
+
+Keep single `reviewer.md` but add internal Phase 1 and Phase 2 sections that the Reviewer interprets contextually.
+
+**Pros:**
+- Single file to maintain
+- All review knowledge in one place
+
+**Cons:**
+- Ambiguity - Reviewer must determine which phase applies
+- No explicit signal from Orchestrator about current phase
+- Risk of confusion when spawning the role
+
+### Option 3: Single Reviewer Role with Phase Parameter
+
+Keep single `reviewer.md` with distinct Phase 1 and Phase 2 sections. Orchestrator explicitly passes the phase when spawning:
+
+```
+You are the Reviewer.
+
+<paste reviewer.md content>
+
+Phase: internal  # or "coderabbit"
+Branch: <branch-name>
+...
+```
+
+**Pros:**
+- Single file to maintain
+- Explicit phase signal from Orchestrator
+- Clear separation of responsibilities per phase
+- Orchestrator controls the workflow gate
+
+**Cons:**
+- Slightly more complex spawning template
+- Reviewer must parse phase parameter
+
+## Decision
+
+**Option 3: Single Reviewer Role with Phase Parameter**
+
+The Orchestrator will spawn the Reviewer twice during the SDLC cycle:
+1. **Phase 1 (internal)** - After Implementer creates Draft PR, before marking ready
+2. **Phase 2 (coderabbit)** - After PR is marked ready and CodeRabbit completes
+
+This approach:
+- Keeps review knowledge centralized in one file
+- Gives Orchestrator explicit control over the gate
+- Maintains the principle of fresh context per spawn
+- Clearly separates internal validation from external feedback processing
+
+### Phase Responsibilities
+
+**Phase 1 (Internal Review):**
+- Validate implementation against ADR Decision
+- Check all PLAN.md stages completed
+- Run tests and check coverage
+- Verify scope adherence
+- Report: approve to proceed or request changes
+
+**Phase 2 (CodeRabbit Review):**
+- Review CodeRabbit findings
+- Address or dismiss each finding with rationale
+- Verify no regressions from fixes
+- Report: approve to merge or request changes
+
+## Consequences
+
+### What Becomes Easier
+- CodeRabbit only analyzes vetted code
+- Single review cycle for external tools (typically)
+- Clear gate preventing premature external review
+- Centralized review documentation
+
+### What Becomes Harder
+- Two Reviewer spawns per cycle instead of one
+- Draft PR workflow required (already GitHub native)
+- Slightly longer SDLC timeline per feature
+
+### Follow-up Work
+- None identified - changes are isolated to role documentation
+
+## Decision History
+
+1. **2024-01-26** - Three options presented to user: separate roles, unified with sections, single role with phase parameter
+2. **2024-01-26** - User approved Option 3: Single Reviewer Role with Phase Parameter

--- a/.state/feature-two-phase-review-workflow/PLAN.md
+++ b/.state/feature-two-phase-review-workflow/PLAN.md
@@ -1,0 +1,163 @@
+# PLAN: Two-Phase Review Workflow
+
+## Open Questions
+
+None - approach is well-defined.
+
+## Stages
+
+### Stage 1: Update Orchestrator Flow Diagram
+
+**Goal:** Modify the flow diagram in orchestrator.md to show Draft PR and two review phases.
+
+**Files:**
+- `.claude/skills/roles/references/orchestrator.md`
+
+**Changes:**
+- [x] Update ASCII flow diagram to show:
+  - Implementer creates Draft PR (not regular PR)
+  - Internal Reviewer validates before marking ready
+  - PR marked ready-for-review triggers CodeRabbit
+  - Second Reviewer phase for CodeRabbit feedback
+- [x] Show the gate between internal review and CodeRabbit clearly
+
+**Considerations:**
+- Keep diagram readable despite added complexity
+- Use consistent box/arrow styling
+
+---
+
+### Stage 2: Update Orchestrator Steps
+
+**Goal:** Modify the numbered steps section to reflect two-phase review.
+
+**Files:**
+- `.claude/skills/roles/references/orchestrator.md`
+
+**Changes:**
+- [x] Step 3: Change "PR" to "Draft PR"
+- [x] Add Step 4: Spawn Reviewer with `Phase: internal`
+- [x] Add Step 5: Gate - only proceed if internal review passes, then mark PR ready
+- [x] Update Step 6: Wait for CodeRabbit (now after PR marked ready)
+- [x] Update Step 7: Spawn Reviewer with `Phase: coderabbit`
+- [x] Renumber subsequent steps (Product Owner validation, Maintainer merge)
+
+**Considerations:**
+- Maintain clear gate language
+- Update step numbers consistently
+
+---
+
+### Stage 3: Update Orchestrator Spawning Template
+
+**Goal:** Add phase parameter to the Reviewer spawning template example.
+
+**Files:**
+- `.claude/skills/roles/references/orchestrator.md`
+
+**Changes:**
+- [x] Update "Spawning Roles" section example to show phase parameter:
+  ```
+  You are the Reviewer.
+
+  <paste full content from references/reviewer.md here>
+
+  Phase: internal  # or "coderabbit"
+  Branch: <branch-name>
+  ...
+  ```
+
+**Considerations:**
+- Keep example clear and copy-pastable
+- Show both phase values as comment
+
+---
+
+### Stage 4: Update Reviewer Role Documentation
+
+**Goal:** Add Phase 1 and Phase 2 sections with distinct responsibilities.
+
+**Files:**
+- `.claude/skills/roles/references/reviewer.md`
+
+**Changes:**
+- [x] Add "## Phase Parameter" section explaining the two phases
+- [x] Add "## Phase 1: Internal Review" section with:
+  - Focus: ADR compliance, PLAN completion, tests, scope
+  - Process: Review before PR is marked ready
+  - Output: Approve to proceed or request changes
+- [x] Add "## Phase 2: CodeRabbit Review" section with:
+  - Focus: Address CodeRabbit findings
+  - Process: Review after CodeRabbit completes
+  - Output: Approve to merge or request changes
+- [x] Update "Review Process" section to reference phases
+- [x] Keep shared checklist and reporting format
+
+**Considerations:**
+- Maintain clarity about which phase applies when
+- Keep common elements (test running, reporting format) unified
+
+---
+
+### Stage 5: Update README Flow Diagram
+
+**Goal:** Update the roles README.md flow diagram to reflect two-phase review.
+
+**Files:**
+- `.claude/skills/roles/README.md`
+
+**Changes:**
+- [x] Update ASCII flow diagram to show:
+  - Draft PR creation
+  - Internal Reviewer phase
+  - PR marked ready
+  - CodeRabbit phase
+  - Reviewer (CodeRabbit) phase
+- [x] Keep diagram aligned with orchestrator.md diagram
+
+**Considerations:**
+- README diagram is simpler than orchestrator - may need less detail
+- Ensure consistency between both diagrams
+
+---
+
+### Stage 6: Verification
+
+**Goal:** Verify all changes are consistent and acceptance criteria met.
+
+**Files:**
+- All modified files
+
+**Checks:**
+- [x] Orchestrator flow shows Draft PR before internal review
+- [x] Orchestrator flow shows PR marked ready only after internal approval
+- [x] Reviewer documentation distinguishes Phase 1 vs Phase 2
+- [x] README flow reflects two-phase approach
+- [x] CodeRabbit clearly gated behind internal review
+- [x] All diagrams consistent with each other
+
+## Dependencies
+
+```
+Stage 1 ──┐
+          ├──▶ Stage 4 ──▶ Stage 5 ──▶ Stage 6
+Stage 2 ──┤
+          │
+Stage 3 ──┘
+```
+
+- Stages 1, 2, 3 can be done in parallel (all orchestrator.md changes)
+- Stage 4 (reviewer.md) can start after Stage 3 (needs to match spawning template)
+- Stage 5 (README) should follow Stage 4 (needs to match reviewer phases)
+- Stage 6 (verification) is final
+
+## Progress
+
+| Stage | Status | Notes |
+|-------|--------|-------|
+| 1. Orchestrator Flow Diagram | Complete | Added Draft PR, two Reviewer phases, Gate box |
+| 2. Orchestrator Steps | Complete | Steps 1-9 with Draft PR, Phase 1/2 reviews, Gate |
+| 3. Orchestrator Spawning Template | Complete | Added "Spawning the Reviewer" subsection with Phase parameter |
+| 4. Reviewer Documentation | Complete | Added Phase Parameter, Phase 1, Phase 2 sections |
+| 5. README Flow Diagram | Complete | Updated to match orchestrator diagram |
+| 6. Verification | Complete | All acceptance criteria verified |

--- a/.state/feature-two-phase-review-workflow/REQUIREMENTS.md
+++ b/.state/feature-two-phase-review-workflow/REQUIREMENTS.md
@@ -1,0 +1,55 @@
+# Requirements: Two-Phase Review Workflow
+
+## Problem Statement
+CodeRabbit triggers immediately when a PR is created, before any internal review has occurred. This wastes CodeRabbit's analysis on code that may have structural issues, ADR violations, or other problems that an internal Reviewer would catch. The result is:
+- CodeRabbit feedback mixed with issues that should have been caught internally
+- Potential for multiple CodeRabbit review cycles when one would suffice
+- Inefficient use of external review resources
+
+## Desired Outcome
+A two-phase review process where:
+1. **Phase 1 (Internal):** Code is reviewed internally before external tools see it
+2. **Phase 2 (External):** CodeRabbit reviews only after internal review passes
+
+This ensures CodeRabbit analyzes code that has already been vetted for structural correctness and ADR compliance.
+
+## Scope
+
+### In Scope
+- Update `references/orchestrator.md` - modify flow diagram and step descriptions
+- Update `references/reviewer.md` - clarify the Reviewer's role in internal vs post-CodeRabbit review
+- Update `references/README.md` (roles skill) - update the SDLC flow diagram
+
+### Out of Scope
+- Changes to other roles (Architect, Implementer, Product Owner)
+- Modifications to CodeRabbit configuration
+- Changes to the requirements gathering or planning phases
+
+## Acceptance Criteria
+- [ ] Orchestrator flow shows Draft PR creation before internal review
+- [ ] Orchestrator flow shows PR marked ready-for-review only after internal Reviewer approves
+- [ ] Reviewer role documentation distinguishes between Phase 1 (internal) and Phase 2 (post-CodeRabbit) responsibilities
+- [ ] README flow diagram reflects the two-phase approach
+- [ ] The workflow clearly gates CodeRabbit behind internal review approval
+
+## Proposed Flow (Reference for Implementation)
+```
+Current:
+  Implementer → Create PR → CodeRabbit → Reviewer → Fix issues
+
+Proposed:
+  Implementer → Create Draft PR → Internal Reviewer → Fix internal issues →
+  Mark PR Ready → CodeRabbit → Address CodeRabbit feedback → Done
+```
+
+## Constraints
+- Draft PR mechanism must be compatible with GitHub's draft PR feature
+- Internal Reviewer must have clear criteria for when to approve moving to Phase 2
+
+## Context
+- This change optimizes the existing SDLC workflow defined in the roles skill
+- CodeRabbit is an external AI code review tool that runs on PR creation/updates
+- The Reviewer role already exists but currently runs after CodeRabbit
+
+---
+**Sign-off:** Approved by user

--- a/agents/skills/roles/README.md
+++ b/agents/skills/roles/README.md
@@ -33,13 +33,30 @@ User Request
                └────────┬────────┘  from PLAN        │
                         │                            │
                         ▼                            │
-               ┌─────────────────┐  Validates ───────┤
-               │    Reviewer     │  against ADR+PLAN │
-               └────────┬────────┘                   │
+                   [Draft PR]                        │
                         │                            │
                         ▼                            │
                ┌─────────────────┐                   │
-               │  Product Owner  │───────────────────┘ Verifies ADR Context
+               │    Reviewer     │  Phase 1: Internal│
+               │ (Phase: internal)  ADR+PLAN check  │
+               └────────┬────────┘                   │
+                        │                            │
+                   ┌────┴────┐                       │
+                   │  Gate   │ Mark PR ready         │
+                   └────┬────┘                       │
+                        │                            │
+                        ▼                            │
+                  [CodeRabbit]  External review      │
+                        │                            │
+                        ▼                            │
+               ┌─────────────────┐                   │
+               │    Reviewer     │  Phase 2: Address │
+               │(Phase: coderabbit) findings        │
+               └────────┬────────┘                   │
+                        │                            │
+                        ▼                            │
+               ┌─────────────────┐  Validates ───────┘
+               │  Product Owner  │  against REQUIREMENTS
                └────────┬────────┘
                         │
                         ▼

--- a/agents/skills/roles/references/reviewer.md
+++ b/agents/skills/roles/references/reviewer.md
@@ -2,22 +2,38 @@
 
 Validates implementation against the ADR. Fresh session without context pollution.
 
+## Phase Parameter
+
+The Reviewer is spawned twice during the SDLC cycle, with a `Phase` parameter indicating which review to perform:
+
+- **Phase: internal** - First review, before PR is marked ready for external review
+- **Phase: coderabbit** - Second review, after CodeRabbit external review completes
+
+Check your spawn parameters to determine which phase applies.
+
 ## Responsibilities
 
 - Validate implementation matches ADR Decision and Execution Stages
 - Ensure scope wasn't expanded beyond what was decided
 - Run full test suite
-- Check CodeRabbit review
 - Report findings
 - Never merges - just reports
 
-## Review Process
+---
+
+## Phase 1: Internal Review
+
+**When:** After Implementer creates Draft PR, before marking ready for external review.
+
+**Focus:** ADR compliance, PLAN completion, tests, scope adherence.
+
+### Internal Review Process
 
 1. Read the ADR at `.state/<branch-name>/ADR.md`
 
 2. Validate against ADR:
    - Does implementation match the Decision?
-   - Are all Execution Stages completed?
+   - Are all PLAN.md stages completed (checkboxes marked `[x]`)?
    - Did implementer stay within scope (check Consequences for what was deferred)?
    - Are files listed in stages actually modified?
 
@@ -32,34 +48,74 @@ Validates implementation against the ADR. Fresh session without context pollutio
    cargo tarpaulin
    ```
 
-5. Check CodeRabbit:
-   ```bash
-   gh pr view <PR_NUMBER> --comments | grep -i coderabbit
-   ```
-   Wait for actual review (not "processing").
-
-6. Review PR Diff:
+5. Review PR Diff:
    ```bash
    gh pr diff <PR_NUMBER>
    ```
 
-## Reporting
+### Internal Review Output
 
-Report to orchestrator:
+Report to Orchestrator:
 - ADR compliance (matches/deviates)
+- PLAN completion status
 - Test results (pass/fail)
-- CodeRabbit findings
-- Recommendation (approve/request changes)
+- Scope assessment
+- **Recommendation:** Approve to proceed (mark PR ready) OR request changes
+
+**Gate:** The PR should only be marked ready for external review after internal approval.
+
+---
+
+## Phase 2: CodeRabbit Review
+
+**When:** After PR is marked ready and CodeRabbit external review completes.
+
+**Focus:** Address CodeRabbit findings, verify no regressions from fixes.
+
+### CodeRabbit Review Process
+
+1. Check CodeRabbit findings:
+   ```bash
+   gh pr view <PR_NUMBER> --comments | grep -i coderabbit
+   ```
+   Ensure review is complete (not "processing").
+
+2. For each CodeRabbit finding:
+   - **Address:** Make the suggested fix if valid
+   - **Dismiss:** Provide rationale if finding is not applicable
+   - Document decision for each finding
+
+3. If fixes were made, verify no regressions:
+   ```bash
+   cargo test
+   ./tests/e2e_test.sh
+   ```
+
+4. Review final PR state:
+   ```bash
+   gh pr diff <PR_NUMBER>
+   ```
+
+### CodeRabbit Review Output
+
+Report to Orchestrator:
+- Summary of CodeRabbit findings
+- Actions taken for each finding (addressed/dismissed with rationale)
+- Test results after fixes (if any)
+- **Recommendation:** Approve to merge OR request changes
+
+---
 
 ## Key Rules
 
 - Always read the ADR first
 - Validate against ADR, not assumptions
 - Never merge - report to orchestrator
+- Check your Phase parameter to know which review to perform
 
 ## Verification Checklist
 
-Before approving, complete each step:
+Before approving (either phase), complete each step:
 
 1. `ls .state/<branch>/` - confirm ADR.md and PLAN.md exist
 2. For each PLAN.md stage:


### PR DESCRIPTION
## Summary

Implements a two-phase review workflow (Option 3 from ADR: Single Reviewer Role with Phase Parameter) to gate CodeRabbit behind internal review, reducing wasted analysis cycles and improving efficiency.

**Key Changes:**
- Orchestrator spawns Reviewer twice: Phase 1 (internal) before marking PR ready, Phase 2 (coderabbit) after CodeRabbit completes
- Reviewer role now has distinct sections for each phase with clear responsibilities
- Flow diagram updated: Implementer -> Draft PR -> Internal Review -> Gate -> CodeRabbit -> CodeRabbit Review -> Merge

## Files Modified

| File | Changes |
|------|---------|
| `agents/skills/roles/README.md` | Updated flow diagram for consistency |
| `agents/skills/roles/references/orchestrator.md` | Added 9-step workflow with Draft PR, two review phases, and "Spawning the Reviewer" subsection with Phase parameter |
| `agents/skills/roles/references/reviewer.md` | Added Phase Parameter section, Phase 1 (Internal Review), and Phase 2 (CodeRabbit Review) with distinct responsibilities |
| `.state/feature-two-phase-review-workflow/ADR.md` | Architecture decision record |
| `.state/feature-two-phase-review-workflow/PLAN.md` | Implementation plan |
| `.state/feature-two-phase-review-workflow/REQUIREMENTS.md` | Product requirements |

## ADR

See [`.state/feature-two-phase-review-workflow/ADR.md`](.state/feature-two-phase-review-workflow/ADR.md) for the full architecture decision record.

**Decision:** Single Reviewer Role with Phase Parameter - keeps review knowledge centralized while giving Orchestrator explicit control over the gate.

## Test Plan

- [x] Verify orchestrator.md flow diagram shows Draft PR before internal review
- [x] Verify orchestrator.md shows Gate between internal review and CodeRabbit
- [x] Verify reviewer.md distinguishes Phase 1 vs Phase 2 responsibilities
- [x] Verify README.md diagram is consistent with orchestrator.md
- [x] Verify all acceptance criteria from PLAN.md Stage 6 are met

## Review Status

- [x] Phase 1 Internal Review: APPROVED
- [x] Phase 2 CodeRabbit Review: APPROVED (no actionable findings)
- [x] Product Owner: APPROVED (all 5 acceptance criteria passed)

---

Generated with [Claude Code](https://claude.com/claude-code)