### PR TITLE
fix(tui): move [opt] indicator to prefix position

### DIFF
--- a/src/tui/widgets/file_explorer.rs
+++ b/src/tui/widgets/file_explorer.rs
@@ -843,12 +843,13 @@ impl Widget for FileExplorerWidget<'_> {
                     let checkbox = if *is_checked { "[x] " } else { "[ ] " };
                     spans.push(Span::styled(checkbox, theme.text_secondary_style()));
                 }
-                spans.push(Span::styled(name.as_str(), theme.text_style()));
 
-                // Add [opt] indicator if backup exists
+                // Add [opt] indicator prefix if backup exists
                 if *has_bak {
-                    spans.push(Span::styled(" [opt]", theme.accent_style()));
+                    spans.push(Span::styled("[opt] ", theme.accent_style()));
                 }
+
+                spans.push(Span::styled(name.as_str(), theme.text_style()));
 
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled(


### PR DESCRIPTION
## Summary
- Moves the `[opt]` indicator from suffix to prefix position in the file list

Before: `session-2024-01-15.cast [opt]  (claude, 1.5 MB)`
After: `[opt] session-2024-01-15.cast  (claude, 1.5 MB)`

## Test plan
- [x] `cargo test` passes
- [x] `cargo clippy` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated backup indicator display in the file explorer to appear before item names instead of after.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->