### PR TITLE
feat(cli): rename transform command to optimize

### DIFF
--- a/.state/feature-optimize-ui-improvements/ADR.md
+++ b/.state/feature-optimize-ui-improvements/ADR.md
@@ -1,0 +1,118 @@
+# ADR: Optimize UI Improvements
+
+## Status
+Accepted
+
+## Context
+
+The current "transform" feature has several usability issues identified during user testing:
+
+1. **Terminology confusion**: "Transform" is a technical term that doesn't convey what the feature does (silence removal). Users expect clearer, action-oriented terminology like "optimize."
+
+2. **Dialog readability**: The context menu highlight style uses `fg(theme.background)` which resolves to `Color::Reset` (transparent), resulting in white text on a green background that is difficult to read.
+
+3. **Undiscoverable restore**: The 'r' shortcut for restore is not obvious to users. Having both direct shortcuts and context menu access creates confusion about the interaction model.
+
+4. **No visual feedback for optimized files**: After optimizing a file, there's no visual indicator in the file list showing which files have been processed. Users must remember or check manually.
+
+5. **Stale file size**: After optimization, the file size shown in the list doesn't update, creating confusion about whether the operation succeeded.
+
+## Decision
+
+### Comprehensive UI Polish Approach
+
+We will implement a full UI improvement pass that addresses all usability issues while also improving code quality for future maintainability. This includes:
+
+1. **Rename "Transform" to "Optimize" everywhere** - both user-facing strings AND internal identifiers for consistency
+2. **Add `highlight_style()` theme method** - reusable style for highlighted/selected items in dialogs
+3. **Fix dialog highlighting** - use black text on green background for readability
+4. **Remove 'r' direct shortcut** - restore only accessible via context menu
+5. **Add [opt] indicator** - styled indicator in file list for optimized files (those with .bak backup)
+6. **Add hint/subtitle** - explain what "Optimize" does in the context menu
+7. **Auto-refresh file list** - reload file metadata after mutations (optimize, restore, delete)
+8. **Update footer shortcuts** - remove 'r' from footer, reflect current shortcuts accurately
+
+### Rationale
+
+- **Internal rename**: Keeping internal code aligned with user-facing terminology reduces cognitive overhead for future developers
+- **Reusable highlight_style()**: Prevents the highlighting bug from recurring in future dialogs
+- **Context menu only for restore**: Simplifies the mental model - common actions (play, optimize) have shortcuts, rare actions (restore) use menu
+- **Auto-refresh**: Users expect the UI to reflect the current state of files after any operation
+
+### Design Details
+
+#### Internal Identifier Renames
+```
+Mode::TransformResult       -> Mode::OptimizeResult
+ContextMenuItem::Transform  -> ContextMenuItem::Optimize
+TransformResultState        -> OptimizeResultState
+transform_result            -> optimize_result
+transform_session()         -> optimize_session()
+render_transform_result_modal() -> render_optimize_result_modal()
+```
+
+Note: The `Transform` trait in `src/asciicast/transform.rs` and `TransformResult` struct in `transform_ops.rs` will NOT be renamed - they are general-purpose internal abstractions.
+
+#### Theme Addition
+```rust
+impl Theme {
+    /// Style for highlighted/selected items in dialogs and menus.
+    /// Uses black text on accent background for readability.
+    pub fn highlight_style(&self) -> Style {
+        Style::default()
+            .fg(Color::Black)
+            .bg(self.accent)
+            .add_modifier(Modifier::BOLD)
+    }
+}
+```
+
+#### Context Menu Label Change
+```
+Before: "Transform (remove silence)"
+After:  "Optimize"
+        "  Removes silence from recording"  <- hint as subtitle/second line
+```
+
+#### File List Indicator
+Files with a `.bak` backup will display `[opt]` suffix in accent color:
+```
+session-2024-01-15.cast [opt]  (claude, 1.5 MB)
+```
+
+#### File Metadata Refresh
+After optimize/restore operations, reload the file's metadata from disk to update:
+- File size
+- Modified time (though not currently displayed in list, may be used for sorting)
+
+## Consequences
+
+### Positive
+- Clearer, more intuitive terminology for users
+- Readable dialog highlighting
+- Consistent interaction model (shortcuts for common, menu for rare)
+- Visual feedback for optimization status at a glance
+- Accurate file sizes after operations
+- Reusable theme pattern for future dialogs
+- Internal code aligns with user-facing terms
+
+### Negative
+- More changes = more testing required
+- Snapshot tests will need updates
+- May affect any external documentation referencing "transform"
+
+### Risks
+- **Low**: All changes are in the TUI layer, no changes to core transform logic
+- **Medium**: Snapshot test updates may be tedious but straightforward
+- **Mitigation**: Break into small stages, verify each stage independently
+
+## Testing Strategy
+
+1. **Unit tests**: Update existing tests for renamed identifiers
+2. **Snapshot tests**: Update TUI snapshots for:
+   - Context menu appearance
+   - Help modal (remove 'r' shortcut)
+   - Optimize result modal
+   - File list with [opt] indicator
+3. **Manual testing**: Verify dialog readability, file refresh after optimize/restore
+4. **Regression**: Ensure core transform functionality unchanged

--- a/.state/feature-optimize-ui-improvements/PLAN.md
+++ b/.state/feature-optimize-ui-improvements/PLAN.md
@@ -1,0 +1,530 @@
+# Execution Plan: Optimize UI Improvements
+
+## Overview
+Comprehensive UI polish for the transform/optimize feature. Broken into 10 small, testable stages.
+
+**Branch:** `feature/optimize-ui-improvements`
+
+---
+
+## Stage 1: Add `highlight_style()` to Theme
+
+### Objective
+Add a reusable theme method for highlighted/selected items in dialogs.
+
+### Files to Modify
+- `src/tui/theme.rs`
+
+### Implementation
+1. Add `highlight_style()` method to the `Theme` impl block
+2. Returns black text on accent background with bold modifier
+3. Add unit test for the new method
+
+### Code Change
+```rust
+// Add to Theme impl (after success_style):
+
+/// Style for highlighted/selected items in dialogs and menus.
+/// Uses black text on accent background for readability.
+pub fn highlight_style(&self) -> Style {
+    Style::default()
+        .fg(Color::Black)
+        .bg(self.accent)
+        .add_modifier(Modifier::BOLD)
+}
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder theme
+```
+
+### Verification
+- New method exists and compiles
+- Unit test passes
+
+---
+
+## Stage 2: Fix Context Menu Highlight Styling
+
+### Objective
+Use the new `highlight_style()` for context menu selected items instead of broken `fg(theme.background)`.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. In `render_context_menu_modal()`, replace the manual style construction with `theme.highlight_style()`
+2. This fixes the readability issue (black text on green)
+
+### Code Change
+```rust
+// In render_context_menu_modal(), replace:
+let style = if is_selected {
+    Style::default()
+        .fg(theme.background)
+        .bg(theme.accent)
+        .add_modifier(Modifier::BOLD)
+} else if is_disabled {
+    // ...
+};
+
+// With:
+let style = if is_selected {
+    theme.highlight_style()
+} else if is_disabled {
+    // ...
+};
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder list_app
+cargo insta test
+```
+
+### Verification
+- Context menu highlight is now black text on green
+- Manual testing: open context menu, verify readability
+
+---
+
+## Stage 3: Rename Mode::TransformResult to Mode::OptimizeResult
+
+### Objective
+Begin internal identifier rename - start with the Mode enum variant.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. Rename `Mode::TransformResult` to `Mode::OptimizeResult`
+2. Update all references in the file (match arms, comparisons)
+3. Update test names if any reference the old name
+
+### Code Change
+```rust
+// In Mode enum:
+/// Optimize result mode - showing optimization results or error
+OptimizeResult,
+
+// Update all match arms and references
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder list_app
+```
+
+### Verification
+- All tests pass
+- No compiler errors
+
+---
+
+## Stage 4: Rename TransformResultState and Related Identifiers
+
+### Objective
+Complete internal identifier rename for result state.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. Rename `TransformResultState` struct to `OptimizeResultState`
+2. Rename `transform_result` field to `optimize_result`
+3. Rename `handle_transform_result_key()` to `handle_optimize_result_key()`
+4. Rename `render_transform_result_modal()` to `render_optimize_result_modal()`
+5. Update all references
+
+### Code Change
+```rust
+/// Holds the result of an optimize operation for display in modal.
+#[derive(Debug, Clone)]
+pub struct OptimizeResultState {
+    /// The filename that was optimized
+    pub filename: String,
+    /// The result (Ok with data or Err with message)
+    pub result: Result<TransformResult, String>,  // Keep TransformResult from asciicast module
+}
+
+// Rename field:
+optimize_result: Option<OptimizeResultState>,
+
+// Rename methods:
+fn handle_optimize_result_key(...) { ... }
+pub fn render_optimize_result_modal(...) { ... }
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder list_app
+cargo insta test
+```
+
+### Verification
+- All tests pass
+- Snapshot tests may need updates
+
+---
+
+## Stage 5: Rename ContextMenuItem::Transform and transform_session()
+
+### Objective
+Complete context menu and action method rename.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. Rename `ContextMenuItem::Transform` to `ContextMenuItem::Optimize`
+2. Rename `transform_session()` to `optimize_session()`
+3. Update `label()` method: "Transform (remove silence)" -> "Optimize"
+4. Update `shortcut()` comment if needed (still 't')
+5. Update all references in match arms
+
+### Code Change
+```rust
+pub enum ContextMenuItem {
+    Play,
+    Optimize,  // was Transform
+    Restore,
+    Delete,
+    AddMarker,
+}
+
+impl ContextMenuItem {
+    pub fn label(&self) -> &'static str {
+        match self {
+            ContextMenuItem::Optimize => "Optimize",
+            // ...
+        }
+    }
+}
+
+// Rename method:
+fn optimize_session(&mut self) -> Result<()> { ... }
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder list_app
+```
+
+### Verification
+- Tests pass (update test assertions for new enum variant name)
+
+---
+
+## Stage 6: Update UI Strings and Modal Titles
+
+### Objective
+Update all user-facing strings from "transform" to "optimize."
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. Footer text: "t: transform" -> "t: optimize"
+2. Help modal: "Transform (remove silence)" -> "Optimize (removes silence)"
+3. Result modal title: "Transform Complete" -> "Optimization Complete"
+4. Result modal title: "Transform Failed" -> "Optimization Failed"
+5. Status messages (if any)
+
+### Code Change
+```rust
+// Footer (Mode::Normal):
+"...| t: optimize | ..."
+
+// Help modal:
+Line::from(vec![
+    Span::styled("  t", Style::default().fg(theme.accent)),
+    Span::raw("           Optimize (removes silence)"),
+]),
+
+// Result modal titles:
+let title = " Optimization Complete ";
+let title = " Optimization Failed ";
+```
+
+### Testing
+```bash
+cargo insta test
+```
+
+### Verification
+- Update all affected snapshots
+- Manual verification of UI text
+
+---
+
+## Stage 7: Remove 'r' Direct Shortcut
+
+### Objective
+Remove the direct 'r' keyboard shortcut for restore; keep restore only in context menu.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. Remove `KeyCode::Char('r')` handler from `handle_normal_key()`
+2. Remove "r: restore" from footer text in `Mode::Normal`
+3. Remove 'r' shortcut line from help modal
+4. Keep restore functionality in `execute_context_menu_action()`
+
+### Code Change
+```rust
+// In handle_normal_key(), DELETE:
+KeyCode::Char('r') => {
+    // ... entire block
+}
+
+// In footer (Mode::Normal), change:
+"↑↓: navigate | Enter: menu | p: play | t: optimize | d: delete | ?: help | q: quit"
+// (removed "| r: restore")
+
+// In render_help_modal(), DELETE:
+Line::from(vec![
+    Span::styled("  r", Style::default().fg(theme.accent)),
+    Span::raw("           Restore from backup"),
+]),
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder list_app
+cargo insta test
+```
+
+### Verification
+- Pressing 'r' in normal mode does nothing
+- Restore still works via context menu
+- Footer and help modal updated
+
+---
+
+## Stage 8: Add Hint/Subtitle to Context Menu
+
+### Objective
+Add a description line under "Optimize" in the context menu explaining what it does.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. In `render_context_menu_modal()`, add a subtitle line after "Optimize"
+2. Style as secondary text
+3. Only show for Optimize item (not all items)
+
+### Code Change
+```rust
+// In render_context_menu_modal(), modify the loop:
+for (idx, item) in ContextMenuItem::ALL.iter().enumerate() {
+    // ... existing code to build label and style ...
+
+    lines.push(Line::from(Span::styled(
+        format!("{}{}", prefix, label),
+        style,
+    )));
+
+    // Add hint for Optimize
+    if matches!(item, ContextMenuItem::Optimize) {
+        lines.push(Line::from(Span::styled(
+            "       Removes silence from recording",
+            Style::default().fg(theme.text_secondary),
+        )));
+    }
+}
+```
+
+### Testing
+```bash
+cargo insta test
+```
+
+### Verification
+- Context menu shows hint under Optimize
+- Hint is dimmed/secondary color
+
+---
+
+## Stage 9: Add [opt] Indicator for Optimized Files
+
+### Objective
+Display `[opt]` indicator in file list for files that have a .bak backup.
+
+### Files to Modify
+- `src/tui/widgets/file_explorer.rs`
+- `src/tui/list_app.rs` (to pass backup status per file)
+
+### Implementation
+
+Option A (Simpler): Check backup in FileExplorerWidget render
+1. In `FileExplorerWidget::render()`, for each visible item, check `has_backup()`
+2. Add `[opt]` span with accent color if backup exists
+
+Option B (Better performance): Pre-compute and pass backup status
+1. Add `has_backup: bool` field to `FileItem` or compute during iteration
+2. Pass backup status through visible_items iteration
+
+We'll use Option A for simplicity since backup check is just a file existence check.
+
+### Code Change (file_explorer.rs)
+```rust
+// In FileExplorerWidget render(), modify item_data collection:
+use crate::asciicast::has_backup;
+
+let item_data: Vec<(String, String, String, bool, bool)> = self
+    .explorer
+    .visible_items()
+    .map(|(_, item, is_checked)| {
+        let has_bak = has_backup(std::path::Path::new(&item.path));
+        (
+            item.name.clone(),
+            item.agent.clone(),
+            format_size(item.size),
+            is_checked,
+            has_bak,  // new field
+        )
+    })
+    .collect();
+
+// In the items iterator, add [opt] indicator:
+let items: Vec<ListItem> = item_data
+    .iter()
+    .map(|(name, agent, size_str, is_checked, has_bak)| {
+        let mut spans = vec![];
+        if show_checkboxes { /* ... */ }
+        spans.push(Span::styled(name.as_str(), theme.text_style()));
+
+        // Add [opt] indicator if backup exists
+        if *has_bak {
+            spans.push(Span::styled(" [opt]", theme.accent_style()));
+        }
+
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            format!("({}, {})", agent, size_str),
+            theme.text_secondary_style(),
+        ));
+        ListItem::new(Line::from(spans))
+    })
+    .collect();
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder file_explorer
+cargo insta test
+```
+
+### Verification
+- Files with .bak show [opt] in green
+- Files without backup don't show indicator
+- Indicator updates after optimize/restore
+
+---
+
+## Stage 10: Auto-Refresh File Metadata After Mutations
+
+### Objective
+Update file size (and other metadata) in the list after optimize/restore operations.
+
+### Files to Modify
+- `src/tui/widgets/file_explorer.rs`
+- `src/tui/list_app.rs`
+
+### Implementation
+1. Add `update_item_metadata()` method to `FileExplorer` that reloads a file's size from disk
+2. Call this method after `optimize_session()` and `restore_session()` succeed
+3. The method finds the item by path and updates its size field
+
+### Code Change (file_explorer.rs)
+```rust
+impl FileExplorer {
+    /// Update metadata for an item by reloading from disk.
+    /// Returns true if item was found and updated.
+    pub fn update_item_metadata(&mut self, path: &str) -> bool {
+        if let Some(idx) = self.items.iter().position(|item| item.path == path) {
+            // Reload metadata from disk
+            if let Ok(metadata) = std::fs::metadata(path) {
+                self.items[idx].size = metadata.len();
+                // Could also update modified time if needed
+                return true;
+            }
+        }
+        false
+    }
+}
+```
+
+### Code Change (list_app.rs)
+```rust
+// In optimize_session(), after successful transform:
+Ok(result) => {
+    self.preview_cache.invalidate(path);
+    // Refresh file metadata in explorer
+    self.explorer.update_item_metadata(&item.path);
+    Ok(result)
+}
+
+// In restore_session(), after successful restore:
+Ok(()) => {
+    self.preview_cache.invalidate(path);
+    // Refresh file metadata in explorer
+    self.explorer.update_item_metadata(&item.path);
+    self.status_message = Some(format!("Restored from backup: {}", name));
+}
+```
+
+### Testing
+```bash
+cargo test -p agent-session-recorder file_explorer
+cargo test -p agent-session-recorder list_app
+```
+
+### Verification
+- File size updates after optimize (should decrease)
+- File size updates after restore (may change)
+- [opt] indicator updates correctly
+
+---
+
+## Completion Criteria
+
+All stages complete when:
+
+1. `cargo build` succeeds
+2. `cargo test` passes
+3. `cargo clippy` reports no warnings
+4. `cargo fmt --check` passes
+5. All snapshot tests updated and passing
+6. Manual verification:
+   - Context menu shows "Optimize" with readable highlight
+   - Hint appears under Optimize in menu
+   - 'r' shortcut removed, restore only via menu
+   - [opt] indicator appears for optimized files
+   - File size updates after operations
+   - Footer shows correct shortcuts
+   - Help modal updated
+
+---
+
+## Stage Dependency Graph
+
+```
+Stage 1 (theme) ─────┐
+                     v
+Stage 2 (fix highlight) ──> Stage 6 (UI strings)
+                     │
+Stage 3 (Mode rename) ──> Stage 4 (struct rename) ──> Stage 5 (method rename)
+                                                              │
+                                                              v
+                     Stage 7 (remove 'r') ──> Stage 8 (hint) ──> Stage 9 ([opt])
+                                                                        │
+                                                                        v
+                                                              Stage 10 (refresh)
+```
+
+Stages 1-2 can run in parallel with Stages 3-5.
+Stages 6-10 should run sequentially.

--- a/.state/feature-optimize-ui-improvements/REQUIREMENTS.md
+++ b/.state/feature-optimize-ui-improvements/REQUIREMENTS.md
@@ -1,0 +1,45 @@
+# Requirements: Optimize UI Improvements
+
+## Problem Statement
+The current "transform" feature has usability issues: the terminology is unclear ("transform" doesn't convey what happens), the dialog has readability problems with highlighted text (white on green), the 'r' shortcut for restore is undiscoverable, and there's no visual indicator for which files have been optimized.
+
+## User Stories
+- As a user, I want the feature called "optimize" instead of "transform" so that the terminology is clearer
+- As a user, I want a hint explaining what optimization does so that I understand the operation
+- As a user, I want to read highlighted text in dialogs so that I can see which option is selected
+- As a user, I want restore to only be accessible via the context menu to simplify the shortcut model
+- As a user, I want to see which files have been optimized so that I can track status at a glance
+- As a user, I want the file size to update after optimization so the list reflects current state
+
+## Acceptance Criteria
+
+### Terminology Change
+1. [ ] All UI references to "transform" are renamed to "optimize"
+2. [ ] Menu items, labels, and prompts use "optimize" terminology
+3. [ ] A hint/description explains what optimization does (e.g., "removes silence")
+
+### Dialog Highlighting Fix
+4. [ ] Highlighted line text in dialogs uses black color (not white)
+5. [ ] Highlighted text is readable against green highlight background
+
+### Restore Access Change
+6. [ ] Direct 'r' keyboard shortcut for restore is removed
+7. [ ] Restore action is only accessible through the context menu
+8. [ ] Context menu still contains the restore option
+
+### Optimized File Indicator
+9. [ ] Files with a `.bak` backup file display an indicator (e.g., [o]) in the file list
+10. [ ] The indicator is removed when the file is restored (backup deleted)
+11. [ ] The indicator is visible and distinguishable from the filename
+
+### File Size Update
+12. [ ] File size in the list updates after optimization to reflect actual current size
+
+## Out of Scope
+- Changes to the actual optimization algorithm (silence removal logic)
+- New optimization options or settings
+- Rename functionality
+- Undo/redo beyond single restore from backup
+
+## Open Questions
+- None - requirements confirmed

--- a/.state/feature-optimize-ui-improvements/REVIEW.md
+++ b/.state/feature-optimize-ui-improvements/REVIEW.md
@@ -1,0 +1,227 @@
+# Code Review: PR #68 - Optimize UI Improvements
+
+**Reviewer:** Adversarial Code Review
+**Date:** 2026-01-29
+**Branch:** feature/optimize-ui-improvements
+**Status:** CHANGES REQUESTED
+
+---
+
+## Summary
+
+This PR implements UI terminology changes from "Transform" to "Optimize", adds a highlight_style() theme method, removes the 'r' shortcut for restore, adds an [opt] indicator for optimized files, and implements auto-refresh of file metadata after mutations.
+
+The implementation is **largely correct** but has several issues that need addressing before merge.
+
+---
+
+## Findings
+
+### FINDING 1: Preview Panel Still Shows "r to restore" [MEDIUM]
+
+**File:** `/Users/simon.sanladerer/git/simon/agent-session-recorder/src/tui/widgets/file_explorer.rs:936`
+
+**Issue:** The preview panel still displays `(r to restore)` hint when a backup is available, but the 'r' shortcut has been removed from normal mode. This creates user confusion - they see a hint for a shortcut that doesn't work.
+
+```rust
+Span::styled(" (r to restore)", theme.text_secondary_style()),
+```
+
+**Impact:** Users will try pressing 'r' based on the preview hint, but nothing will happen since the shortcut was removed. The hint should either:
+1. Be removed entirely, or
+2. Be changed to mention the context menu (e.g., "Restore via menu")
+
+**ADR Compliance:** ADR Section 4 ("Remove 'r' direct shortcut") was only partially implemented - the shortcut was removed but the UI hint was not updated.
+
+---
+
+### FINDING 2: Context Menu 'r' Shortcut Not Functional [MEDIUM]
+
+**File:** `/Users/simon.sanladerer/git/simon/agent-session-recorder/src/tui/list_app.rs:80-88`
+
+**Issue:** The `ContextMenuItem::Restore` still has `shortcut() => "r"`, and this is displayed in the context menu, but `handle_context_menu_key()` (lines 484-511) does NOT handle the 'r' key press. The context menu only handles navigation keys, Enter, and Esc.
+
+```rust
+pub fn shortcut(&self) -> &'static str {
+    match self {
+        ContextMenuItem::Play => "p",
+        ContextMenuItem::Optimize => "t",
+        ContextMenuItem::Restore => "r",  // Displayed but not functional
+        ...
+    }
+}
+```
+
+And in `handle_context_menu_key()`:
+```rust
+match key.code {
+    KeyCode::Up | KeyCode::Char('k') => { ... }
+    KeyCode::Down | KeyCode::Char('j') => { ... }
+    KeyCode::Enter => { ... }
+    KeyCode::Esc => { ... }
+    _ => {}  // 'r' falls through here and does nothing
+}
+```
+
+**Impact:** The context menu shows "(r)" next to Restore, implying users can press 'r' to restore, but pressing 'r' does nothing. Either:
+1. Add shortcut key handling to `handle_context_menu_key()`, or
+2. Remove the shortcut display from context menu items
+
+**ADR Compliance:** The ADR says "restore only accessible via context menu" but doesn't clarify whether shortcuts should work WITHIN the menu. The current state is confusing.
+
+---
+
+### FINDING 3: [opt] Indicator Not Appearing in Snapshot Tests [MEDIUM]
+
+**File:** `/Users/simon.sanladerer/git/simon/agent-session-recorder/tests/integration/snapshot_tui_test.rs:551-564`
+
+**Issue:** The snapshot test `snapshot_file_explorer_preview_with_backup` passes `has_backup: true` to the widget, but the rendered output shows NO `[opt]` indicator in the file list.
+
+Looking at the snapshot file:
+```
+│> [ ] 20240117-session4.cast  (gemini, 1.0 MB)            │
+```
+Expected with [opt]:
+```
+│> [ ] 20240117-session4.cast [opt]  (gemini, 1.0 MB)      │
+```
+
+**Root Cause:** The `has_backup` parameter on `FileExplorerWidget` is only used for the preview panel's backup status indicator. The `[opt]` indicator in the file LIST is determined by calling `has_backup()` for EACH file item individually during render (line 816 of file_explorer.rs). Since these are test file paths that don't actually exist on disk, `has_backup()` returns false.
+
+```rust
+let has_bak = has_backup(std::path::Path::new(&item.path));
+```
+
+**Impact:**
+1. There is no test coverage for the `[opt]` indicator feature
+2. The test name `preview_with_backup` is misleading - it doesn't test the list indicator
+
+**Recommendation:** Add a separate test that creates actual temporary .cast and .bak files to verify the [opt] indicator appears.
+
+---
+
+### FINDING 4: update_item_metadata() Has No Tests [LOW]
+
+**File:** `/Users/simon.sanladerer/git/simon/agent-session-recorder/src/tui/widgets/file_explorer.rs:719-730`
+
+**Issue:** The new `update_item_metadata()` function has no unit tests.
+
+```rust
+pub fn update_item_metadata(&mut self, path: &str) -> bool {
+    if let Some(idx) = self.items.iter().position(|item| item.path == path) {
+        if let Ok(metadata) = std::fs::metadata(path) {
+            self.items[idx].size = metadata.len();
+            return true;
+        }
+    }
+    false
+}
+```
+
+**Concerns:**
+1. What happens if the path doesn't exist? (returns false, which is fine)
+2. What if the path exists in items but file doesn't exist on disk? (returns false, silent failure)
+3. No test verifies the size is actually updated correctly
+
+**Impact:** Low - the function is simple and unlikely to fail, but missing test coverage for a new feature.
+
+---
+
+### FINDING 5: Potential Performance Issue with has_backup() per Item [LOW]
+
+**File:** `/Users/simon.sanladerer/git/simon/agent-session-recorder/src/tui/widgets/file_explorer.rs:815-816`
+
+**Issue:** The code calls `has_backup()` for every visible item on EVERY render:
+
+```rust
+.map(|(_, item, is_checked)| {
+    let has_bak = has_backup(std::path::Path::new(&item.path));
+    ...
+})
+```
+
+The `has_backup()` function performs a filesystem check (Path::exists()):
+```rust
+pub fn has_backup(original_path: &Path) -> bool {
+    backup_path_for(original_path).exists()
+}
+```
+
+**Impact:** For a list of 100 sessions displayed on screen, this performs 100 filesystem stat() calls every time the UI redraws (on every keypress, tick, resize). While individual stat() calls are fast, this could cause noticeable lag on slow filesystems (network drives, old HDDs).
+
+**Recommendation:** The PLAN.md Stage 9 actually considered this:
+> "Option A (Simpler): Check backup in FileExplorerWidget render
+> Option B (Better performance): Pre-compute and pass backup status"
+
+Option A was chosen "for simplicity" but this may not scale well. Consider caching backup status in FileItem or computing it once per session list refresh.
+
+---
+
+### FINDING 6: Incomplete ADR Compliance - Help Modal Line Count [LOW]
+
+**File:** `/Users/simon.sanladerer/git/simon/agent-session-recorder/tests/integration/snapshots/integration__snapshot_tui_test__help_modal.snap`
+
+**Issue:** The help modal snapshot shows an extra blank line at the bottom:
+
+```
+     │  Esc         Clear filters                          │
+     │                                                          │
+     │Press any key to close                                    │
+     │                                                          │
++    │                                                          │
+     └──────────────────────────────────────────────────────────┘
+```
+
+The diff shows `modal_height = 26.min(...)` was updated with comment "removed r shortcut" but there's now an extra blank line padding because one line was removed but the height wasn't adjusted correctly.
+
+**Impact:** Minor visual inconsistency - extra whitespace in help modal.
+
+---
+
+## Test Results
+
+```
+cargo test: PASSED (330 tests, 0 failures)
+cargo clippy: PASSED (no warnings)
+cargo fmt --check: PASSED
+```
+
+---
+
+## ADR/PLAN Compliance Checklist
+
+| Stage | Requirement | Status |
+|-------|-------------|--------|
+| 1 | Add highlight_style() to Theme | DONE |
+| 2 | Fix context menu highlight styling | DONE |
+| 3 | Rename Mode::TransformResult to OptimizeResult | DONE |
+| 4 | Rename TransformResultState and related | DONE |
+| 5 | Rename ContextMenuItem::Transform and methods | DONE |
+| 6 | Update UI strings and modal titles | DONE |
+| 7 | Remove 'r' direct shortcut | PARTIAL - preview hint not updated |
+| 8 | Add hint/subtitle to context menu | DONE |
+| 9 | Add [opt] indicator | DONE but no test coverage |
+| 10 | Auto-refresh file metadata | DONE but no test |
+
+---
+
+## Verdict
+
+**CHANGES REQUESTED**
+
+The PR implements most features correctly, but has two **MEDIUM** severity issues that create user-facing inconsistencies:
+
+1. The "r to restore" hint in the preview panel contradicts the removed shortcut
+2. Context menu shortcuts are displayed but non-functional
+
+These should be fixed before merge. The LOW severity issues are acceptable to address in a follow-up.
+
+---
+
+## Recommended Actions
+
+1. **[REQUIRED]** Remove or update the "(r to restore)" text in file_explorer.rs:936
+2. **[REQUIRED]** Either add shortcut handling to handle_context_menu_key() OR remove shortcut display from context menu
+3. **[OPTIONAL]** Add test coverage for [opt] indicator with actual temp files
+4. **[OPTIONAL]** Add unit test for update_item_metadata()
+5. **[OPTIONAL]** Consider caching has_backup() results for performance

--- a/.state/fix-transform-backup-bugs/ADR.md
+++ b/.state/fix-transform-backup-bugs/ADR.md
@@ -1,0 +1,126 @@
+# ADR: Fix Transform and Backup Bugs from PR #65 Review
+
+## Status
+Accepted
+
+## Context
+
+Five bugs were identified during adversarial review of PR #65 (context menu and transform integration). These bugs affect:
+- Data integrity (temp file leaks, non-atomic operations)
+- UX (selectable disabled options)
+- CI consistency (version mismatch)
+
+The existing codebase already uses the temp+rename pattern for `apply_transforms()`, establishing a precedent for atomic file operations.
+
+## Decision
+
+### Approach: Targeted Fixes with Existing Patterns
+
+Since these are well-defined bugfixes (not new features), the approach is straightforward:
+- Apply the established temp+rename pattern to `restore_from_backup()`
+- Add cleanup logic for failure paths in existing operations
+- Add guard logic for disabled context menu items
+- Align CI version with Cargo.toml
+
+**Rationale:** The codebase already demonstrates the correct patterns (temp+rename in `apply_transforms`). These bugs are deviations from those patterns that need alignment.
+
+### Fix Details
+
+#### Bug 1: Temp file cleanup on rename failure
+**Location:** `src/asciicast/transform_ops.rs:108-115`
+**Fix:** Wrap the rename in a match and clean up temp file on error before propagating.
+
+```rust
+// Current (buggy):
+fs::rename(&temp_path, path)
+    .with_context(|| ...)?;
+
+// Fixed:
+if let Err(e) = fs::rename(&temp_path, path) {
+    let _ = fs::remove_file(&temp_path); // Best-effort cleanup
+    return Err(e).with_context(|| ...);
+}
+```
+
+#### Bug 2: Atomic restore operation
+**Location:** `src/asciicast/transform_ops.rs:141-152`
+**Fix:** Apply the same temp+rename pattern used by `apply_transforms()`.
+
+```rust
+// Current (non-atomic):
+fs::copy(&backup, path)?;
+
+// Fixed:
+let temp_path = path.with_extension("cast.tmp");
+fs::copy(&backup, &temp_path)?;
+if let Err(e) = fs::rename(&temp_path, path) {
+    let _ = fs::remove_file(&temp_path);
+    return Err(e).with_context(|| ...);
+}
+```
+
+#### Bug 3: Delete removes backup file
+**Location:** `src/tui/list_app.rs:562-576`
+**Fix:** After successful main file deletion, attempt to delete `.cast.bak` if it exists.
+
+```rust
+// After successful remove_file(&path):
+let backup = backup_path_for(&path);
+if backup.exists() {
+    let _ = std::fs::remove_file(&backup); // Best-effort
+    // Optionally update status message
+}
+```
+
+#### Bug 4: Disabled Restore option not selectable
+**Location:** `src/tui/list_app.rs:523-539`
+**Fix:** Check if Restore is disabled before executing the action.
+
+```rust
+fn execute_context_menu_action(&mut self) -> Result<()> {
+    let action = ContextMenuItem::ALL[self.context_menu_idx];
+
+    // Guard: don't execute disabled Restore
+    if matches!(action, ContextMenuItem::Restore) {
+        if let Some(item) = self.explorer.selected_item() {
+            if !has_backup(Path::new(&item.path)) {
+                self.status_message = Some("No backup exists".into());
+                self.mode = Mode::Normal;
+                return Ok(());
+            }
+        }
+    }
+
+    self.mode = Mode::Normal;
+    // ... rest of match
+}
+```
+
+#### Bug 5: cargo-insta version alignment
+**Location:** `.github/workflows/ci.yml:199`
+**Fix:** Change `1.43.1` to `1.46.1`.
+
+## Consequences
+
+### Positive
+- Temp files will be cleaned up on all failure paths
+- Restore operation becomes crash-safe (atomic)
+- Deleting recordings cleans up all associated files
+- Context menu UX matches visual state
+- CI/local development consistency
+
+### Negative
+- None significant; these are correctness fixes
+
+### Risks
+- Low risk; all changes are localized and testable
+- Atomic operations may behave differently on network filesystems (rename semantics vary), but this matches existing `apply_transforms()` behavior
+
+## Testing Strategy
+
+Each bug fix should have corresponding test coverage:
+1. **Bug 1:** Test that temp file doesn't exist after failed rename (mock or use permissions)
+2. **Bug 2:** Test restore atomicity (verify backup unchanged after restore, test idempotency)
+3. **Bug 3:** Test delete removes both `.cast` and `.cast.bak`
+4. **Bug 4:** Test that disabled Restore shows message but doesn't call restore_from_backup
+5. **Bug 5:** Run snapshot tests after CI update

--- a/.state/fix-transform-backup-bugs/PLAN.md
+++ b/.state/fix-transform-backup-bugs/PLAN.md
@@ -1,0 +1,244 @@
+# Execution Plan: Fix Transform and Backup Bugs
+
+## Overview
+Five targeted bugfixes from PR #65 review. Each stage fixes one bug and includes relevant tests.
+
+---
+
+## Stage 1: Temp File Cleanup on Rename Failure
+
+### Objective
+Ensure temp files are cleaned up when `fs::rename()` fails in `apply_transforms()`.
+
+### Files to Modify
+- `src/asciicast/transform_ops.rs`
+
+### Implementation
+1. Change lines 114-115 from direct `?` propagation to explicit error handling
+2. On rename failure, attempt to remove the temp file before returning error
+3. Preserve original error context in the returned error
+
+### Code Change
+```rust
+// Replace:
+fs::rename(&temp_path, path)
+    .with_context(|| format!("Failed to replace original file: {}", path.display()))?;
+
+// With:
+if let Err(e) = fs::rename(&temp_path, path) {
+    // Clean up temp file on failure (best-effort, ignore cleanup errors)
+    let _ = fs::remove_file(&temp_path);
+    return Err(e).with_context(|| format!("Failed to replace original file: {}", path.display()));
+}
+```
+
+### Testing
+- Existing tests must continue to pass
+- Consider adding a test that verifies no `.cast.tmp` files remain after operation (both success and failure paths)
+
+### Verification
+```bash
+cargo test -p agent-session-recorder transform_ops
+```
+
+---
+
+## Stage 2: Atomic Restore Operation
+
+### Objective
+Make `restore_from_backup()` use the same atomic temp+rename pattern as `apply_transforms()`.
+
+### Files to Modify
+- `src/asciicast/transform_ops.rs`
+
+### Implementation
+1. Replace direct `fs::copy(&backup, path)` with atomic pattern:
+   - Copy backup to temp file (`.cast.tmp`)
+   - Rename temp file to target
+   - Clean up temp on rename failure
+
+### Code Change
+```rust
+pub fn restore_from_backup(path: &Path) -> Result<()> {
+    let backup = backup_path_for(path);
+
+    if !backup.exists() {
+        anyhow::bail!("No backup exists for: {}", path.display());
+    }
+
+    // Use atomic temp+rename pattern for crash safety
+    let temp_path = path.with_extension("cast.tmp");
+
+    fs::copy(&backup, &temp_path)
+        .with_context(|| format!("Failed to copy backup to temp file: {}", backup.display()))?;
+
+    if let Err(e) = fs::rename(&temp_path, path) {
+        // Clean up temp file on failure
+        let _ = fs::remove_file(&temp_path);
+        return Err(e).with_context(|| format!("Failed to restore from backup: {}", path.display()));
+    }
+
+    Ok(())
+}
+```
+
+### Testing
+- Existing `restore_from_backup` tests must pass
+- Add test verifying backup file is unchanged after restore
+- Verify idempotency: multiple restores produce same result
+
+### Verification
+```bash
+cargo test -p agent-session-recorder restore_from_backup
+```
+
+---
+
+## Stage 3: Delete Removes Backup File
+
+### Objective
+When deleting a `.cast` file, also delete the corresponding `.cast.bak` if it exists.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. In `delete_session()`, after successful main file deletion
+2. Check if backup exists using `backup_path_for()`
+3. Attempt to delete backup (best-effort, don't fail if backup deletion fails)
+4. Update status message to indicate if backup was also deleted
+
+### Code Change
+```rust
+fn delete_session(&mut self) -> Result<()> {
+    if let Some(item) = self.explorer.selected_item() {
+        let path = item.path.clone();
+        let name = item.name.clone();
+
+        // Delete the file
+        if let Err(e) = std::fs::remove_file(&path) {
+            self.status_message = Some(format!("Failed to delete: {}", e));
+        } else {
+            // Also delete backup if it exists
+            let backup = backup_path_for(std::path::Path::new(&path));
+            let backup_deleted = if backup.exists() {
+                std::fs::remove_file(&backup).is_ok()
+            } else {
+                false
+            };
+
+            // Remove from explorer to keep UI in sync
+            self.explorer.remove_item(&path);
+
+            // Update status message
+            self.status_message = Some(if backup_deleted {
+                format!("Deleted: {} (and backup)", name)
+            } else {
+                format!("Deleted: {}", name)
+            });
+        }
+    }
+    Ok(())
+}
+```
+
+### Testing
+- Manual testing: delete a file with backup, verify both are removed
+- Manual testing: delete a file without backup, verify clean deletion
+
+### Verification
+```bash
+cargo test -p agent-session-recorder list_app
+cargo clippy
+```
+
+---
+
+## Stage 4: Disabled Restore Option Not Selectable
+
+### Objective
+Prevent executing `restore_session()` when Restore is disabled (no backup exists) via context menu.
+
+### Files to Modify
+- `src/tui/list_app.rs`
+
+### Implementation
+1. In `execute_context_menu_action()`, before executing Restore
+2. Check if backup exists
+3. If no backup, show status message and return early without calling `restore_session()`
+
+### Code Change
+```rust
+fn execute_context_menu_action(&mut self) -> Result<()> {
+    let action = ContextMenuItem::ALL[self.context_menu_idx];
+
+    // Guard: check if Restore is disabled (no backup)
+    if matches!(action, ContextMenuItem::Restore) {
+        if let Some(item) = self.explorer.selected_item() {
+            let path = std::path::Path::new(&item.path);
+            if !has_backup(path) {
+                self.mode = Mode::Normal;
+                self.status_message = Some("No backup exists for this file".to_string());
+                return Ok(());
+            }
+        }
+    }
+
+    self.mode = Mode::Normal; // Close menu first
+
+    match action {
+        // ... existing match arms
+    }
+    Ok(())
+}
+```
+
+### Testing
+- Manual testing: open context menu on file without backup, select Restore, verify message shown
+- Verify `r` shortcut in normal mode still shows appropriate message
+
+### Verification
+```bash
+cargo test -p agent-session-recorder list_app
+cargo clippy
+```
+
+---
+
+## Stage 5: Align cargo-insta Version in CI
+
+### Objective
+Ensure CI uses the same cargo-insta version as Cargo.toml.
+
+### Files to Modify
+- `.github/workflows/ci.yml`
+
+### Implementation
+1. Change line 199 from `1.43.1` to `1.46.1`
+
+### Code Change
+```yaml
+# Replace:
+run: cargo install cargo-insta --version 1.43.1
+
+# With:
+run: cargo install cargo-insta --version 1.46.1
+```
+
+### Testing
+- Run snapshot tests locally to verify they pass
+
+### Verification
+```bash
+cargo insta test
+```
+
+---
+
+## Completion Criteria
+
+All stages complete when:
+1. `cargo test` passes
+2. `cargo clippy` reports no warnings
+3. `cargo fmt --check` passes
+4. All five bugs are fixed as specified in REQUIREMENTS.md

--- a/.state/fix-transform-backup-bugs/REQUIREMENTS.md
+++ b/.state/fix-transform-backup-bugs/REQUIREMENTS.md
@@ -1,0 +1,84 @@
+# Requirements: Fix Transform and Backup Bugs from PR #65 Review
+
+## Problem Statement
+
+Five bugs were identified during adversarial review of PR #65 (context menu and transform integration). These bugs range from data integrity issues (temp file leaks, non-atomic operations) to UX problems (selectable disabled options) and CI inconsistencies. All must be fixed to ensure reliable transform operations and proper user experience.
+
+## User Stories
+
+- As a user, I want temp files cleaned up after failures so that my disk doesn't fill with orphaned `.cast.tmp` files
+- As a user, I want restore operations to be atomic so that a crash during restore doesn't corrupt both my file and backup
+- As a user, I want delete to remove all associated files so that backup files don't accumulate and waste disk space
+- As a user, I want disabled menu options to be truly non-selectable so that I don't get confusing error messages
+- As a maintainer, I want CI and local development to use the same cargo-insta version so that snapshot tests behave consistently
+
+## Acceptance Criteria
+
+### Bug 1: Temp file cleanup on rename failure (HIGH)
+**Location:** `src/asciicast/transform_ops.rs:108-115`
+
+1. When `fs::rename()` fails after writing to `.cast.tmp`, the temp file MUST be deleted
+2. The cleanup MUST happen regardless of why the rename failed (permissions, disk full, etc.)
+3. Original error context MUST be preserved in the returned error message
+4. Existing unit tests MUST continue to pass
+
+### Bug 2: Atomic restore operation (HIGH)
+**Location:** `src/asciicast/transform_ops.rs:141-152`
+
+1. `restore_from_backup()` MUST use atomic temp+rename pattern (write to temp file, then rename)
+2. If rename fails, temp file MUST be cleaned up
+3. A crash during restore MUST NOT corrupt the original file
+4. A crash during restore MUST NOT corrupt the backup file
+5. Restore operation MUST remain idempotent (can be retried on failure)
+
+### Bug 3: Delete removes backup file (HIGH)
+**Location:** `src/tui/list_app.rs:562-576`
+
+1. When deleting a `.cast` file, the corresponding `.cast.bak` file MUST also be deleted if it exists
+2. Failure to delete backup MUST NOT prevent deletion of the main file
+3. Status message SHOULD indicate if backup was also deleted
+4. If only backup deletion fails, a warning SHOULD be shown but operation succeeds
+
+### Bug 4: Disabled Restore option not selectable (MEDIUM)
+**Location:** `src/tui/list_app.rs` (context menu handling)
+
+1. When Restore option is disabled (no backup exists), pressing Enter on it MUST NOT execute `restore_session()`
+2. Arrow keys MUST skip over disabled items OR Enter on disabled item MUST be a no-op with visual feedback
+3. The current visual styling (grayed out) MUST remain
+4. Shortcut key `r` in normal mode SHOULD behave consistently (either skip or show "no backup" message)
+
+### Bug 5: cargo-insta version alignment (LOW)
+**Location:** `Cargo.toml:55` and `.github/workflows/ci.yml:199`
+
+1. CI workflow MUST use same cargo-insta version as Cargo.toml
+2. Version in CI: `1.43.1` -> `1.46.1` (to match Cargo.toml)
+3. All snapshot tests MUST pass after version update
+
+## Out of Scope
+
+- Adding new transform operations
+- Changing backup file naming conventions (`.bak` suffix)
+- Adding compression or encryption to backups
+- Changing context menu keyboard navigation paradigm
+- Upgrading other CI dependencies
+
+## Constraints
+
+- Must maintain backward compatibility with existing `.cast` and `.cast.bak` files
+- Atomic operations should use temp+rename pattern consistent with existing `apply_transforms()` code
+- No new dependencies should be added for file operations (use `std::fs`)
+- Tests must remain deterministic and not rely on timing
+
+## Technical Notes
+
+The temp+rename pattern for atomicity:
+1. Write to `<file>.tmp`
+2. Call `fs::rename(temp, target)` - atomic on most filesystems
+3. On rename failure, clean up temp file
+4. This prevents partial writes from corrupting the target
+
+For context menu disabled items, two valid approaches:
+- Skip disabled items during navigation (up/down arrows)
+- Allow selection but make Enter a no-op with feedback
+
+Either approach is acceptable as long as `restore_session()` is never called when no backup exists via the context menu path.

--- a/.state/fix-transform-backup-bugs/REVIEW.md
+++ b/.state/fix-transform-backup-bugs/REVIEW.md
@@ -1,0 +1,90 @@
+# Review: Fix Transform and Backup Bugs - Phase internal
+
+## Summary
+
+The implementation correctly addresses all five documented bugs with appropriate fixes. However, there are several concerns around missing test coverage for failure paths, a TOCTOU vulnerability in the restore flow, and inconsistent temp file handling in concurrent scenarios.
+
+---
+
+## Findings
+
+### HIGH Severity
+
+1. **src/tui/list_app.rs:529-537 & 614-618** - TOCTOU Race Condition in Restore Guard
+   - Issue: The guard in `execute_context_menu_action()` checks `has_backup(path)` at line 532, but `restore_session()` checks it again at line 615. Between these checks, the backup file could be deleted by another process (or the user on the command line), causing the guard to pass but the `restore_from_backup()` call to fail with a confusing error.
+   - Impact: While `restore_from_backup()` does have its own check (line 148), the error message is different from the guard's message, causing inconsistent UX. More critically, there's a window where another process could modify the backup.
+   - Fix: This is a low-probability race condition in a single-user TUI application. The impact is minor (just an error message), but the redundant check in `restore_session()` (lines 614-618) is unnecessary since `restore_from_backup()` already handles the no-backup case. Consider removing the redundant check to simplify the code and have one authoritative error path.
+
+2. **src/asciicast/transform_ops.rs:153** - Pre-existing temp file not handled
+   - Issue: If a `.cast.tmp` file already exists (from a previous interrupted operation), `fs::copy()` will overwrite it silently. This is acceptable but there's no cleanup of orphaned temp files.
+   - Impact: If a user had manually created a `.cast.tmp` file or a previous crash left one behind, it would be silently overwritten. This is minor but could lead to confusion.
+   - Fix: Consider checking for and removing pre-existing temp files before starting operations, or using a unique temp filename (e.g., with a timestamp or random suffix).
+
+### MEDIUM Severity
+
+1. **src/asciicast/transform_ops.rs** - Missing test for temp file cleanup on failure
+   - Issue: The PLAN.md (line 37) specifically called for "a test that verifies no `.cast.tmp` files remain after operation (both success and failure paths)" but no such test was added. The existing tests only verify happy paths.
+   - Impact: The temp file cleanup code (lines 116 and 160) is untested. If refactoring breaks this logic, tests won't catch it.
+   - Fix: Add a test that mocks or simulates a rename failure (e.g., by setting target directory read-only) and verifies that no temp file remains.
+
+2. **src/tui/list_app.rs:588-592** - Backup deletion TOCTOU
+   - Issue: Similar to restore, `backup.exists()` (line 588) is checked, then `remove_file(&backup)` is called (line 589). Between these calls, the file could disappear.
+   - Impact: The code correctly handles this (`remove_file(&backup).is_ok()`), so this is more of a code smell than a bug. However, the `exists()` check is redundant.
+   - Fix: Simplify to `let backup_deleted = std::fs::remove_file(&backup).is_ok();` without the exists check. The remove will fail with `NotFound` if the file doesn't exist, and `.is_ok()` handles it.
+
+3. **src/tui/list_app.rs:587** - Path conversion creates owned String unnecessarily
+   - Issue: `backup_path_for(std::path::Path::new(&path))` creates a temporary `Path` from the owned `String` path. This is slightly inefficient.
+   - Impact: Minor performance overhead, not a correctness issue.
+   - Fix: Use `backup_path_for(Path::new(&path))` with `use std::path::Path;` already imported at line 6. The current code works, just verbose.
+
+### LOW Severity
+
+1. **src/asciicast/transform_ops.rs** - Missing test for atomic restore preserving backup
+   - Issue: REQUIREMENTS.md specifies "A crash during restore MUST NOT corrupt the backup file" (acceptance criteria 2.4). While the implementation is correct (backup is only read, never written), there's no explicit test verifying the backup remains unchanged after restore.
+   - Impact: The round-trip test (line 488) partially covers this, but doesn't explicitly assert backup integrity.
+   - Fix: Add explicit assertion in existing tests that backup file content matches original after restore operations.
+
+2. **src/tui/list_app.rs:534** - Message inconsistency between guard and direct call
+   - Issue: Guard message is "No backup exists for this file" (line 534) but `restore_session()` uses "No backup exists for: {name}" (line 616). Inconsistent user-facing messages.
+   - Impact: Minor UX inconsistency.
+   - Fix: Standardize the message format, preferably including the filename for context.
+
+3. **.state/fix-transform-backup-bugs/PLAN.md:147-152** - Manual testing only for Bug 3
+   - Issue: Stage 3 (delete removes backup) has no automated tests, only "Manual testing" listed in verification.
+   - Impact: Regression risk if the delete logic is modified.
+   - Fix: Add unit test that creates a file and backup, calls delete, and verifies both are removed.
+
+---
+
+## Tests
+
+- Unit tests: **PASS** (325 tests)
+- Clippy: **PASS** (no warnings)
+- Test quality concerns:
+  - No tests for failure paths in temp file cleanup
+  - No automated tests for backup deletion on file delete
+  - Missing explicit assertions for backup integrity preservation
+
+---
+
+## ADR Compliance
+
+- Implementation matches Decision: **YES** - All five bugs addressed as specified
+- All PLAN stages complete: **YES** - All stages implemented
+- Scope maintained: **YES** - No scope creep
+
+---
+
+## Recommendation
+
+**REQUEST CHANGES**
+
+### Blocking Items
+
+1. Add test for temp file cleanup on rename failure (MEDIUM severity - documented requirement not met)
+
+### Non-Blocking Items (should be addressed but don't block merge)
+
+1. Consider removing redundant backup existence check in `restore_session()` to simplify error handling
+2. Standardize "No backup exists" message format
+3. Consider adding automated test for delete removing both file and backup

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -236,11 +236,11 @@ After installing, restart your shell or run: source ~/.zshrc"
     )]
     Shell(ShellCommands),
 
-    /// Transform asciicast recordings
-    #[command(long_about = "Apply transformations to asciicast recording files.
+    /// Optimize asciicast recordings (removes silence)
+    #[command(long_about = "Optimize asciicast recording files by removing silence.
 
-Transforms modify the timing or content of recordings. Currently supports
-silence removal, which caps long pauses at a configurable threshold.
+Optimization modifies the timing of recordings by capping long pauses
+at a configurable threshold.
 
 THRESHOLD RESOLUTION:
     1. CLI argument (explicit user intent)
@@ -248,15 +248,15 @@ THRESHOLD RESOLUTION:
     3. Default: 2.0 seconds
 
 EXAMPLES:
-    agr transform --remove-silence session.cast
+    agr optimize --remove-silence session.cast
         Use header's idle_time_limit or default 2.0s threshold
 
-    agr transform --remove-silence=1.5 session.cast
+    agr optimize --remove-silence=1.5 session.cast
         Use explicit 1.5s threshold (note: requires = for value)
 
-    agr transform --remove-silence --output fast.cast session.cast
+    agr optimize --remove-silence --output fast.cast session.cast
         Write to separate file, preserving original")]
-    Transform {
+    Optimize {
         /// Remove silence by capping intervals at threshold
         #[arg(
             long = "remove-silence",
@@ -272,7 +272,7 @@ EXAMPLES:
         #[arg(long, short, value_name = "FILE", help = "Output file path")]
         output: Option<String>,
 
-        /// Path to the .cast file to transform
+        /// Path to the .cast file to optimize
         #[arg(help = "Path to the .cast recording file")]
         file: String,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -319,7 +319,7 @@ fn main() -> Result<()> {
             ShellCommands::Install => commands::shell::handle_install(),
             ShellCommands::Uninstall => commands::shell::handle_uninstall(),
         },
-        Commands::Transform {
+        Commands::Optimize {
             remove_silence,
             output,
             file,
@@ -337,7 +337,7 @@ fn main() -> Result<()> {
 
             // Currently only silence removal is supported
             if remove_silence.is_none() {
-                anyhow::bail!("No transform specified. Use --remove-silence to remove silence.");
+                anyhow::bail!("No optimization specified. Use --remove-silence to remove silence.");
             }
 
             commands::transform::handle_remove_silence(&file, threshold, output.as_deref())

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
@@ -36,17 +36,17 @@ For more information, see: https://github.com/thiscantbeserious/agent-session-re
 Usage: agr <COMMAND>
 
 Commands:
-  record     [37mStart recording a session[0m
-  status     [37mShow storage statistics[0m
-  cleanup    [37mInteractive cleanup of old sessions[0m
-  list       [37mList recorded sessions [aliases: ls][0m
-  analyze    [37mAnalyze a recording with AI[0m
-  marker     [37mManage markers in cast files[0m
-  agents     [37mManage configured agents[0m
-  config     [37mConfiguration management[0m
-  shell      [37mManage shell integration[0m
-  transform  [37mTransform asciicast recordings[0m
-  help       [37mPrint this message or the help of the given subcommand(s)[0m
+  record    [37mStart recording a session[0m
+  status    [37mShow storage statistics[0m
+  cleanup   [37mInteractive cleanup of old sessions[0m
+  list      [37mList recorded sessions [aliases: ls][0m
+  analyze   [37mAnalyze a recording with AI[0m
+  marker    [37mManage markers in cast files[0m
+  agents    [37mManage configured agents[0m
+  config    [37mConfiguration management[0m
+  shell     [37mManage shell integration[0m
+  optimize  [37mOptimize asciicast recordings (removes silence)[0m
+  help      [37mPrint this message or the help of the given subcommand(s)[0m
 
 Options:
   -h, --help

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
@@ -36,17 +36,17 @@ For more information, see: https://github.com/thiscantbeserious/agent-session-re
 Usage: agr <COMMAND>
 
 Commands:
-  record     ESC[37mStart recording a sessionESC[0m
-  status     ESC[37mShow storage statisticsESC[0m
-  cleanup    ESC[37mInteractive cleanup of old sessionsESC[0m
-  list       ESC[37mList recorded sessions [aliases: ls]ESC[0m
-  analyze    ESC[37mAnalyze a recording with AIESC[0m
-  marker     ESC[37mManage markers in cast filesESC[0m
-  agents     ESC[37mManage configured agentsESC[0m
-  config     ESC[37mConfiguration managementESC[0m
-  shell      ESC[37mManage shell integrationESC[0m
-  transform  ESC[37mTransform asciicast recordingsESC[0m
-  help       ESC[37mPrint this message or the help of the given subcommand(s)ESC[0m
+  record    ESC[37mStart recording a sessionESC[0m
+  status    ESC[37mShow storage statisticsESC[0m
+  cleanup   ESC[37mInteractive cleanup of old sessionsESC[0m
+  list      ESC[37mList recorded sessions [aliases: ls]ESC[0m
+  analyze   ESC[37mAnalyze a recording with AIESC[0m
+  marker    ESC[37mManage markers in cast filesESC[0m
+  agents    ESC[37mManage configured agentsESC[0m
+  config    ESC[37mConfiguration managementESC[0m
+  shell     ESC[37mManage shell integrationESC[0m
+  optimize  ESC[37mOptimize asciicast recordings (removes silence)ESC[0m
+  help      ESC[37mPrint this message or the help of the given subcommand(s)ESC[0m
 
 Options:
   -h, --help

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
@@ -20,17 +20,17 @@ Exit code: 2
 Usage: agr <COMMAND>
 
 Commands:
-  record     [37mStart recording a session[0m
-  status     [37mShow storage statistics[0m
-  cleanup    [37mInteractive cleanup of old sessions[0m
-  list       [37mList recorded sessions [aliases: ls][0m
-  analyze    [37mAnalyze a recording with AI[0m
-  marker     [37mManage markers in cast files[0m
-  agents     [37mManage configured agents[0m
-  config     [37mConfiguration management[0m
-  shell      [37mManage shell integration[0m
-  transform  [37mTransform asciicast recordings[0m
-  help       [37mPrint this message or the help of the given subcommand(s)[0m
+  record    [37mStart recording a session[0m
+  status    [37mShow storage statistics[0m
+  cleanup   [37mInteractive cleanup of old sessions[0m
+  list      [37mList recorded sessions [aliases: ls][0m
+  analyze   [37mAnalyze a recording with AI[0m
+  marker    [37mManage markers in cast files[0m
+  agents    [37mManage configured agents[0m
+  config    [37mConfiguration management[0m
+  shell     [37mManage shell integration[0m
+  optimize  [37mOptimize asciicast recordings (removes silence)[0m
+  help      [37mPrint this message or the help of the given subcommand(s)[0m
 
 Options:
   -h, --help     Print help (see more with '--help')

--- a/tests/integration/transform_test.rs
+++ b/tests/integration/transform_test.rs
@@ -80,7 +80,7 @@ fn transform_inplace_modification_works() {
 
     // Run transform without --output (in-place)
     let (stdout, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_eq!(exit_code, 0, "Exit code should be 0. stderr: {}", stderr);
     assert!(
@@ -108,7 +108,7 @@ fn transform_output_preserves_original_file() {
 
     // Run transform with --output
     let (_, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence",
         "--output",
         output_path.to_str().unwrap(),
@@ -142,7 +142,7 @@ fn transform_output_creates_new_file() {
     assert!(!output_path.exists(), "Output file should not exist yet");
 
     let (_, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence",
         "--output",
         output_path.to_str().unwrap(),
@@ -164,7 +164,7 @@ fn transform_output_to_same_path_as_input_works() {
 
     // Using --output with same path as input should work (effectively in-place)
     let (_, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence",
         "--output",
         path_str,
@@ -190,7 +190,7 @@ fn transform_corrupt_json_file_clear_error() {
     let cast_path = create_cast_file(&temp_dir, "corrupt.cast", "{ not valid json at all");
 
     let (stdout, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_ne!(
         exit_code, 0,
@@ -218,7 +218,7 @@ fn transform_truncated_file_clear_error() {
     );
 
     let (stdout, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence",
         truncated_path.to_str().unwrap(),
     ]);
@@ -257,7 +257,7 @@ fn transform_missing_header_clear_error() {
     );
 
     let (stdout, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_ne!(
         exit_code, 0,
@@ -276,7 +276,7 @@ fn transform_missing_header_clear_error() {
 #[test]
 fn transform_file_not_found_clear_error() {
     let (stdout, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence",
         "/nonexistent/path/to/file.cast",
     ]);
@@ -307,7 +307,7 @@ fn transform_permission_denied_clear_error() {
     fs::set_permissions(&cast_path, perms).unwrap();
 
     let (stdout, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     // Restore permissions for cleanup
     let mut perms = fs::metadata(&cast_path).unwrap().permissions();
@@ -337,7 +337,7 @@ fn transform_invalid_threshold_clear_error_before_file_ops() {
 
     // Test with negative threshold
     let (stdout, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence=-1.0",
         cast_path.to_str().unwrap(),
     ]);
@@ -369,7 +369,7 @@ fn transform_invalid_threshold_zero() {
     let cast_path = create_cast_file(&temp_dir, "test.cast", sample_cast_with_long_pauses());
 
     let (stdout, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence=0",
         cast_path.to_str().unwrap(),
     ]);
@@ -392,7 +392,7 @@ fn transform_invalid_threshold_nan() {
     let cast_path = create_cast_file(&temp_dir, "test.cast", sample_cast_with_long_pauses());
 
     let (stdout, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence=notanumber",
         cast_path.to_str().unwrap(),
     ]);
@@ -421,7 +421,7 @@ fn transform_then_parse_produces_valid_asciicast() {
     let cast_path = create_cast_file(&temp_dir, "roundtrip.cast", sample_cast_with_long_pauses());
 
     let (_, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_eq!(exit_code, 0, "Transform should succeed. stderr: {}", stderr);
 
@@ -447,7 +447,7 @@ fn transform_preserves_header_fields() {
     let original = AsciicastFile::parse(&cast_path).unwrap();
 
     let (_, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_eq!(exit_code, 0, "Transform should succeed. stderr: {}", stderr);
 
@@ -476,7 +476,7 @@ fn transform_preserves_all_event_data_fields() {
     let original_types: Vec<_> = original.events.iter().map(|e| e.event_type).collect();
 
     let (_, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_eq!(exit_code, 0, "Transform should succeed. stderr: {}", stderr);
 
@@ -515,7 +515,7 @@ fn transform_preserves_unicode_content() {
     let original_data: Vec<_> = original.events.iter().map(|e| e.data.clone()).collect();
 
     let (_, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_eq!(exit_code, 0, "Transform should succeed. stderr: {}", stderr);
 
@@ -544,7 +544,7 @@ fn transform_multiple_times_cumulative_effect() {
 
     // First transform with 10s threshold
     let (_, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence=10.0",
         cast_path.to_str().unwrap(),
     ]);
@@ -561,7 +561,7 @@ fn transform_multiple_times_cumulative_effect() {
 
     // Second transform with 2s threshold
     let (_, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence=2.0",
         cast_path.to_str().unwrap(),
     ]);
@@ -601,7 +601,7 @@ fn transform_uses_header_idle_time_limit_when_no_cli_threshold() {
     );
 
     let (stdout, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_eq!(exit_code, 0, "Transform should succeed. stderr: {}", stderr);
     assert!(
@@ -629,7 +629,7 @@ fn transform_cli_threshold_overrides_header() {
     );
 
     let (stdout, stderr, exit_code) = run_agr(&[
-        "transform",
+        "optimize",
         "--remove-silence=3.0",
         cast_path.to_str().unwrap(),
     ]);
@@ -656,7 +656,7 @@ fn transform_cli_threshold_overrides_header() {
 
 #[test]
 fn transform_help_shows_remove_silence_option() {
-    let (stdout, stderr, exit_code) = run_agr(&["transform", "--help"]);
+    let (stdout, stderr, exit_code) = run_agr(&["optimize", "--help"]);
 
     assert_eq!(exit_code, 0, "Help should succeed. stderr: {}", stderr);
     assert!(
@@ -677,13 +677,13 @@ fn transform_requires_transform_flag() {
     let cast_path = create_cast_file(&temp_dir, "test.cast", sample_cast_with_long_pauses());
 
     // Run transform without any transform flag
-    let (stdout, stderr, exit_code) = run_agr(&["transform", cast_path.to_str().unwrap()]);
+    let (stdout, stderr, exit_code) = run_agr(&["optimize", cast_path.to_str().unwrap()]);
 
-    assert_ne!(exit_code, 0, "Should fail without transform flag");
+    assert_ne!(exit_code, 0, "Should fail without optimization flag");
     let combined = format!("{}{}", stdout, stderr);
     assert!(
-        combined.contains("remove-silence") || combined.contains("No transform"),
-        "Should indicate need for transform flag. Output: {}",
+        combined.contains("remove-silence") || combined.contains("No optimization"),
+        "Should indicate need for optimization flag. Output: {}",
         combined
     );
 }

--- a/tests/performance/transform_cli_test.rs
+++ b/tests/performance/transform_cli_test.rs
@@ -30,7 +30,7 @@ fn transform_large_file_via_cli_completes() {
 
     let start = std::time::Instant::now();
     let (stdout, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
     let duration = start.elapsed();
 
     assert_eq!(
@@ -70,7 +70,7 @@ fn transform_large_file_output_is_valid_and_playable() {
     let cast_path = create_cast_file(&temp_dir, "large_valid.cast", &large_content);
 
     let (_, stderr, exit_code) =
-        run_agr(&["transform", "--remove-silence", cast_path.to_str().unwrap()]);
+        run_agr(&["optimize", "--remove-silence", cast_path.to_str().unwrap()]);
 
     assert_eq!(
         exit_code, 0,


### PR DESCRIPTION
## Summary
- Renames CLI command from `agr transform` to `agr optimize`
- Aligns CLI with TUI terminology change from PR #68

## Changes
- `src/cli.rs` - Renamed `Commands::Transform` to `Commands::Optimize`, updated help text
- `src/main.rs` - Updated command handler
- `tests/integration/transform_test.rs` - Updated all CLI calls
- `tests/performance/transform_cli_test.rs` - Updated CLI calls
- Snapshot updates for CLI help output

## Test plan
- [x] `cargo test` passes (all 258+ tests)
- [x] `cargo clippy` passes
- [x] Snapshot tests updated and accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed CLI subcommand from "transform" to "optimize". Users must update their command invocations accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->