### PR TITLE
style: fix formatting in transform_ops tests

### DIFF
--- a/src/asciicast/transform_ops.rs
+++ b/src/asciicast/transform_ops.rs
@@ -672,11 +672,17 @@ mod tests {
 
         // Transform 2 - should create NEW backup (previous was deleted by restore)
         let result2 = apply_transforms(&path).unwrap();
-        assert!(result2.backup_created, "New backup should be created since previous was deleted");
+        assert!(
+            result2.backup_created,
+            "New backup should be created since previous was deleted"
+        );
 
         // Restore again - deletes backup again
         restore_from_backup(&path).unwrap();
-        assert!(!has_backup(&path), "Backup should be deleted after second restore");
+        assert!(
+            !has_backup(&path),
+            "Backup should be deleted after second restore"
+        );
 
         // Final bytes should match original
         let final_bytes = fs::read(&path).unwrap();


### PR DESCRIPTION
## Summary
- Fix `cargo fmt` formatting in test assertions

## Test plan
- CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion formatting for better readability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->