### PR TITLE
refactor(terminal): remove re-export chain for TerminalBuffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,8 @@ pub mod tui;
 pub use analyzer::Analyzer;
 pub use asciicast::{AsciicastFile, Event, EventType, Header, MarkerInfo, MarkerManager};
 pub use config::Config;
-pub use player::{play_session, PlaybackResult, TerminalBuffer};
+pub use player::{play_session, PlaybackResult};
+pub use terminal::TerminalBuffer;
 pub use recording::Recorder;
 pub use shell::ShellStatus;
 pub use storage::StorageManager;
-
-// Re-export terminal types under the old module name for backwards compatibility
-pub mod terminal_buffer {
-    pub use crate::player::terminal::*;
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub use analyzer::Analyzer;
 pub use asciicast::{AsciicastFile, Event, EventType, Header, MarkerInfo, MarkerManager};
 pub use config::Config;
 pub use player::{play_session, PlaybackResult};
-pub use terminal::TerminalBuffer;
 pub use recording::Recorder;
 pub use shell::ShellStatus;
 pub use storage::StorageManager;
+pub use terminal::TerminalBuffer;

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -22,10 +22,6 @@
 
 mod asciinema;
 mod native;
-pub mod terminal;
 
 pub use asciinema::{play_session_asciinema, play_session_with_speed};
 pub use native::{play_session, play_session_native, PlaybackResult};
-
-// Re-export terminal types that might be useful externally
-pub use terminal::{Cell, CellStyle, Color, StyledLine, TerminalBuffer};

--- a/src/player/mod.rs
+++ b/src/player/mod.rs
@@ -3,7 +3,6 @@
 //! Provides functionality for playing back asciicast recordings:
 //!
 //! - `native`: Full-featured native player (seeking, markers, viewport scrolling)
-//! - `terminal`: Virtual terminal buffer for rendering escape sequences
 //! - `asciinema`: Legacy wrapper for shelling out to asciinema CLI
 //!
 //! # Usage

--- a/src/player/native.rs
+++ b/src/player/native.rs
@@ -25,7 +25,7 @@ use crossterm::{
 
 use crate::asciicast::AsciicastFile;
 
-use super::terminal::{CellStyle, Color as TermColor, TerminalBuffer};
+use crate::terminal::{CellStyle, Color as TermColor, TerminalBuffer};
 
 /// Result of a playback operation
 #[derive(Debug, Clone)]

--- a/src/player/terminal.rs
+++ b/src/player/terminal.rs
@@ -1,8 +1,0 @@
-//! Virtual terminal buffer for replaying asciicast output.
-//!
-//! This module re-exports from `crate::terminal` for backward compatibility.
-//! All types and implementations have been moved to `src/terminal/`.
-//! Tests have been migrated to `src/terminal/tests/`.
-
-// Re-export all types from the new terminal module for backward compatibility
-pub use crate::terminal::{Cell, CellStyle, Color, StyledLine, TerminalBuffer};

--- a/src/tui/widgets/file_explorer.rs
+++ b/src/tui/widgets/file_explorer.rs
@@ -79,7 +79,7 @@ impl From<SessionInfo> for FileItem {
     }
 }
 
-use crate::terminal_buffer::{Color, StyledLine};
+use crate::terminal::{Color, StyledLine};
 
 /// Enhanced preview information for a session file.
 ///
@@ -115,7 +115,7 @@ impl SessionPreview {
     /// - Never stores all events in memory
     fn load_streaming<P: AsRef<Path>>(path: P) -> Option<Self> {
         use crate::asciicast::{EventType, Header};
-        use crate::terminal_buffer::TerminalBuffer;
+        use crate::terminal::TerminalBuffer;
         use std::fs::File;
         use std::io::{BufRead, BufReader};
 
@@ -241,7 +241,7 @@ impl SessionPreview {
         // Group consecutive cells with same style into spans
         let mut spans: Vec<Span<'static>> = Vec::new();
         let mut current_text = String::new();
-        let mut current_style: Option<crate::terminal_buffer::CellStyle> = None;
+        let mut current_style: Option<crate::terminal::CellStyle> = None;
 
         for cell in &line.cells {
             if Some(cell.style) == current_style {

--- a/tests/integration/snapshot_terminal_test.rs
+++ b/tests/integration/snapshot_terminal_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Tests ANSI escape sequence handling and terminal rendering.
 
-use agr::player::TerminalBuffer;
+use agr::terminal::TerminalBuffer;
 
 /// Helper to create a terminal buffer and process input
 fn process(input: &str) -> String {

--- a/tests/integration/snapshot_tui_test.rs
+++ b/tests/integration/snapshot_tui_test.rs
@@ -576,7 +576,7 @@ fn render_explorer_with_preview_and_backup(
 
 #[test]
 fn snapshot_file_explorer_with_session_preview() {
-    use agr::terminal_buffer::{Cell, CellStyle, Color, StyledLine};
+    use agr::terminal::{Cell, CellStyle, Color, StyledLine};
     use agr::tui::widgets::SessionPreview;
 
     let mut explorer = FileExplorer::new(create_test_file_items());
@@ -621,7 +621,7 @@ fn snapshot_file_explorer_with_session_preview() {
 
 #[test]
 fn snapshot_file_explorer_preview_with_backup() {
-    use agr::terminal_buffer::{Cell, CellStyle, StyledLine};
+    use agr::terminal::{Cell, CellStyle, StyledLine};
     use agr::tui::widgets::SessionPreview;
 
     let mut explorer = FileExplorer::new(create_test_file_items());
@@ -649,7 +649,7 @@ fn snapshot_file_explorer_preview_with_backup() {
 
 #[test]
 fn snapshot_file_explorer_preview_without_backup() {
-    use agr::terminal_buffer::{Cell, CellStyle, StyledLine};
+    use agr::terminal::{Cell, CellStyle, StyledLine};
     use agr::tui::widgets::SessionPreview;
 
     let mut explorer = FileExplorer::new(create_test_file_items());


### PR DESCRIPTION
## Summary
- Remove unnecessary re-export chain for `TerminalBuffer` type
- Update imports to use `crate::terminal` directly instead of going through the player module
- Delete `src/player/terminal.rs` which was only re-exporting types

## Changes
- **src/tui/widgets/file_explorer.rs**: Update 3 imports from `crate::terminal_buffer` to `crate::terminal`
- **tests/integration/snapshot_tui_test.rs**: Update 3 imports from `agr::terminal_buffer` to `agr::terminal`
- **src/lib.rs**: Re-export `TerminalBuffer` directly from terminal module, remove `terminal_buffer` module alias
- **src/player/mod.rs**: Remove terminal submodule declaration and re-exports
- **src/player/native.rs**: Update import to use `crate::terminal`
- **tests/integration/snapshot_terminal_test.rs**: Update import to use `agr::terminal`
- **src/player/terminal.rs**: Deleted (was only re-exporting from terminal module)

## Test plan
- [x] All 366 baseline tests pass
- [x] Ran full test suite 3 times with consistent results
- [x] Clippy reports no warnings
- [x] Documentation builds successfully
- [x] No `terminal_buffer` references remain in codebase
- [x] `TerminalBuffer` accessible via `agr::terminal::TerminalBuffer`

## ADR
See `.state/refactor-terminal-module-cleanup/ADR.md` for the decision rationale (Option A: Outside-In approach).

---
Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Terminal module exports have been reorganized. TerminalBuffer and related types are now exported directly from the terminal module rather than through the player module.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->