### PR TITLE
chore(docs): add pre-merge INDEX.md update to maintainer workflow

### DIFF
--- a/.state/INDEX.md
+++ b/.state/INDEX.md
@@ -33,9 +33,9 @@ git log --oneline -5
 **Current focus:** None (phase complete)
 
 **Recently completed:**
-- SDLC role system improvements with ADR/PLAN separation (PR #56 merged)
-- Skills restructured into roles and instructions (PR #54 merged)
-- Install script fix (PR #55 merged)
+- Release workflow and changelog automation (PR #75)
+- Terminal scroll region support (PR #73)
+- Terminal module re-export cleanup (PR #74)
 
 ## Completed Work
 

--- a/agents/skills/roles/references/maintainer.md
+++ b/agents/skills/roles/references/maintainer.md
@@ -28,19 +28,23 @@ Handles PR lifecycle, merging, and release management.
    - Link to ADR if exists
    - If scope expanded during cycle, document it
 
-4. Pre-merge checklist:
+4. Pre-merge updates (while still on feature branch):
+   - [ ] Update `.state/INDEX.md` "Recently completed" section
+   - [ ] Update `.state/<branch-name>/ADR.md` Status to "Accepted"
+   - [ ] Commit and push these updates to the PR
+
+5. Pre-merge checklist:
    - [ ] PR description reflects final state
    - [ ] All commits accounted for
+   - [ ] INDEX.md updated with this work
    - [ ] Reviewer approved
    - [ ] Product Owner approved
    - If anything unclear → stop and ask user for manual verification
 
-5. Merge after approval:
+6. Merge after approval:
    ```bash
    gh pr merge <PR_NUMBER> --squash
    ```
-
-6. Update ADR Status to Accepted in `.state/<branch-name>/ADR.md`
 
 ## Key Rules
 


### PR DESCRIPTION
## Summary

- Update maintainer role to require INDEX.md updates BEFORE merge (while on feature branch)
- Add missing INDEX.md "Recently completed" entries for PRs #73, #74, #75

## Changes

- `maintainer.md`: Added step 4 "Pre-merge updates" with INDEX.md and ADR status updates
- `INDEX.md`: Updated "Recently completed" section

## Context

This was discovered during PR #75 merge - the INDEX.md update couldn't be pushed after merge because main is protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge workflow procedures with new pre-merge state update requirements on feature branches.
  * Added validation rules: CI must pass and CodeRabbit processing must complete before merging.
  * Reorganized merge checklist sequence for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->