### PR TITLE
fix(release): validate tag matches Cargo.toml version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Check tag matches Cargo.toml version
         run: |
@@ -36,8 +38,8 @@ jobs:
       - name: Check version is newer than latest release
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
-          # Get latest release tag (empty if no releases yet)
-          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
+          # Get latest release tag excluding current tag (empty if no releases yet)
+          LATEST=$(git tag -l 'v*' --sort=-v:refname | grep -v "^v${TAG_VERSION}$" | head -1 | sed 's/^v//')
           if [ -z "$LATEST" ]; then
             echo "No previous releases found. First release!"
             exit 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,29 @@ permissions:
   contents: write
 
 jobs:
+  # Validate tag matches Cargo.toml version
+  validate-version:
+    name: Validate Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check tag matches Cargo.toml version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "Tag version: $TAG_VERSION"
+          echo "Cargo.toml version: $CARGO_VERSION"
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "::error::Version mismatch! Tag ($TAG_VERSION) doesn't match Cargo.toml ($CARGO_VERSION)"
+            echo "Update Cargo.toml version to $TAG_VERSION before tagging."
+            exit 1
+          fi
+          echo "Versions match!"
+
   # Build release binaries for all platforms
   build:
+    needs: validate-version
     name: Build (${{ matrix.artifact }})
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,29 @@ jobs:
           fi
           echo "Versions match!"
 
+      - name: Check version is newer than latest release
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          # Get latest release tag (empty if no releases yet)
+          LATEST=$(git tag -l 'v*' --sort=-v:refname | head -1 | sed 's/^v//')
+          if [ -z "$LATEST" ]; then
+            echo "No previous releases found. First release!"
+            exit 0
+          fi
+          echo "New version: $TAG_VERSION"
+          echo "Latest release: $LATEST"
+          # Compare versions using sort -V
+          HIGHER=$(printf '%s\n%s' "$LATEST" "$TAG_VERSION" | sort -V | tail -1)
+          if [ "$HIGHER" = "$LATEST" ]; then
+            echo "::error::Version $TAG_VERSION is not newer than latest release $LATEST"
+            exit 1
+          fi
+          if [ "$TAG_VERSION" = "$LATEST" ]; then
+            echo "::error::Version $TAG_VERSION already released"
+            exit 1
+          fi
+          echo "Version $TAG_VERSION is newer than $LATEST"
+
   # Build release binaries for all platforms
   build:
     needs: validate-version

--- a/scripts/pre-push-hook.sh
+++ b/scripts/pre-push-hook.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Pre-push hook: Validates version tags before push
+# Prevents pushing tags that don't match Cargo.toml or aren't newer than latest release
+#
+# Install: ln -sf ../../scripts/pre-push-hook.sh .git/hooks/pre-push
+
+set -e
+
+# Read stdin for refs being pushed
+while read local_ref local_sha remote_ref remote_sha; do
+    # Only check version tags (v*)
+    if [[ "$local_ref" =~ ^refs/tags/v[0-9] ]]; then
+        TAG_NAME="${local_ref#refs/tags/}"
+        TAG_VERSION="${TAG_NAME#v}"
+
+        echo "Validating version tag: $TAG_NAME"
+
+        # Check 1: Tag matches Cargo.toml version
+        CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+        if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "ERROR: Tag version ($TAG_VERSION) doesn't match Cargo.toml ($CARGO_VERSION)"
+            echo "Update Cargo.toml version to $TAG_VERSION before tagging."
+            exit 1
+        fi
+        echo "  Cargo.toml version matches: $CARGO_VERSION"
+
+        # Check 2: Version is newer than latest release
+        # Get latest release tag excluding current (in case re-pushing)
+        LATEST=$(git tag -l 'v*' --sort=-v:refname | grep -v "^${TAG_NAME}$" | head -1 | sed 's/^v//')
+
+        if [ -n "$LATEST" ]; then
+            # Compare versions using sort -V
+            HIGHER=$(printf '%s\n%s' "$LATEST" "$TAG_VERSION" | sort -V | tail -1)
+            if [ "$HIGHER" = "$LATEST" ]; then
+                echo "ERROR: Version $TAG_VERSION is not newer than latest release $LATEST"
+                exit 1
+            fi
+            echo "  Version $TAG_VERSION is newer than $LATEST"
+        else
+            echo "  No previous releases found. First release!"
+        fi
+
+        echo "Tag validation passed!"
+    fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary

Adds version validation to prevent releasing tags that don't match `Cargo.toml` or aren't newer than the latest release.

### Changes

**Release workflow validation** (`.github/workflows/release.yml`):
- Validates tag version matches `Cargo.toml` version
- Validates tag version is newer than latest release
- Uses `fetch-depth: 0` to access all historical tags
- Fails fast before build/release jobs run

**Pre-push hook** (`scripts/pre-push-hook.sh`):
- Same validations as CI, but runs locally before push
- Prevents bad tags from ever reaching the remote
- Install: `ln -sf ../../scripts/pre-push-hook.sh .git/hooks/pre-push`

### Test plan

- [ ] Push a tag with version lower than Cargo.toml → should fail
- [ ] Push a tag with version not matching Cargo.toml → should fail  
- [ ] Push a valid new version tag → should succeed

---
ADR: `.state/release-workflow-changelog/ADR.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process with automated version validation to ensure consistency between release tags and version configurations, preventing versioning errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->