### PR TITLE
chore(ci): auto-install pre-push hook via cargo-husky

### DIFF
--- a/.cargo-husky/hooks/pre-push
+++ b/.cargo-husky/hooks/pre-push
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Pre-push hook: Validates version tags before push
+# Prevents pushing tags that don't match Cargo.toml or aren't newer than latest release
+#
+# Install: ln -sf ../../scripts/pre-push-hook.sh .git/hooks/pre-push
+
+set -e
+
+# Read stdin for refs being pushed
+while read local_ref local_sha remote_ref remote_sha; do
+    # Only check version tags (v*)
+    if [[ "$local_ref" =~ ^refs/tags/v[0-9] ]]; then
+        TAG_NAME="${local_ref#refs/tags/}"
+        TAG_VERSION="${TAG_NAME#v}"
+
+        echo "Validating version tag: $TAG_NAME"
+
+        # Check 1: Tag matches Cargo.toml version
+        CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+        if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "ERROR: Tag version ($TAG_VERSION) doesn't match Cargo.toml ($CARGO_VERSION)"
+            echo "Update Cargo.toml version to $TAG_VERSION before tagging."
+            exit 1
+        fi
+        echo "  Cargo.toml version matches: $CARGO_VERSION"
+
+        # Check 2: Version is newer than latest release
+        # Get latest release tag excluding current (in case re-pushing)
+        LATEST=$(git tag -l 'v*' --sort=-v:refname | grep -v "^${TAG_NAME}$" | head -1 | sed 's/^v//')
+
+        if [ -n "$LATEST" ]; then
+            # Compare versions using sort -V
+            HIGHER=$(printf '%s\n%s' "$LATEST" "$TAG_VERSION" | sort -V | tail -1)
+            if [ "$HIGHER" = "$LATEST" ]; then
+                echo "ERROR: Version $TAG_VERSION is not newer than latest release $LATEST"
+                exit 1
+            fi
+            echo "  Version $TAG_VERSION is newer than $LATEST"
+        else
+            echo "  No previous releases found. First release!"
+        fi
+
+        echo "Tag validation passed!"
+    fi
+done
+
+exit 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "atty",
+ "cargo-husky",
  "chrono",
  "clap",
  "clap_complete",
@@ -180,6 +181,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "cargo-husky"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b02b629252fe8ef6460461409564e2c21d0c8e77e0944f3d189ff06c4e932ad"
 
 [[package]]
 name = "cassowary"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tempfile = "3.10"
 assert_cmd = "2.0"
 predicates = "3.1"
 insta = { version = "1.46.1", features = ["filters"] }
+cargo-husky = { version = "1", default-features = false, features = ["user-hooks"] }
 
 [profile.release]
 strip = true


### PR DESCRIPTION
## Summary

Adds cargo-husky to automatically install the pre-push hook when developers run `cargo build` or `cargo test`.

### Changes

- Added `cargo-husky` dev dependency with `user-hooks` feature
- Created `.cargo-husky/hooks/pre-push` with version validation logic

### How it works

When any developer clones the repo and runs `cargo build` or `cargo test`, cargo-husky automatically installs the pre-push hook to `.git/hooks/pre-push`. No manual setup required.

The hook validates:
- Tag version matches `Cargo.toml` version
- Tag version is newer than latest release