### PR TITLE
docs: update README slogan and fix command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝
  ⏺ REC ───────────────────────────────────────────────────────────────────────────────────────
 
-[ Agent Session Recorder ] - auto-record agent sessions and handle the recordings with AI!
+[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.
 ```
 
 [![CI](https://github.com/thiscantbeserious/agent-session-recorder/actions/workflows/ci.yml/badge.svg)](https://github.com/thiscantbeserious/agent-session-recorder/actions/workflows/ci.yml)
@@ -71,7 +71,7 @@ agr status
 asciinema play ~/recorded_agent_sessions/claude/session.cast
 
 # Remove long pauses from a recording (e.g., lunch breaks):
-agr transform --remove-silence session.cast
+agr optimize --remove-silence session.cast
 
 # Add a marker to highlight an important moment:
 agr marker add session.cast 45.2 "Build failed - missing dependency"
@@ -81,17 +81,17 @@ agr marker add session.cast 45.2 "Build failed - missing dependency"
 
 ### Silence Removal
 
-Long pauses in recordings (coffee breaks, lunch, thinking time) can make playback tedious. The transform command removes these silences by capping intervals at a configurable threshold.
+Long pauses in recordings (coffee breaks, lunch, thinking time) can make playback tedious. The optimize command removes these silences by capping intervals at a configurable threshold.
 
 ```bash
 # Use default threshold (2.0 seconds) or header's idle_time_limit:
-agr transform --remove-silence session.cast
+agr optimize --remove-silence session.cast
 
 # Use a custom threshold (1.5 seconds):
-agr transform --remove-silence=1.5 session.cast
+agr optimize --remove-silence=1.5 session.cast
 
 # Write to a new file instead of modifying in-place:
-agr transform --remove-silence --output fast.cast session.cast
+agr optimize --remove-silence --output fast.cast session.cast
 ```
 
 **Threshold Resolution Order:**

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -13,15 +13,16 @@ This document is auto-generated from the CLI definitions.
 - [agents](#agr-agents)
 - [config](#agr-config)
 - [shell](#agr-shell)
+- [optimize](#agr-optimize)
 
 ---
 
 ## agr
 
-[ Agent Session Recorder ] - auto-record agent sessions and handle the recordings with AI!
+[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.
 
 ```
-Agent Session Recorder (AGR) - Record AI agent terminal sessions with asciinema.
+[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.
 
 AGR automatically records your AI coding agent sessions (Claude, Codex, Gemini, etc.)
 to ~/recorded_agent_sessions/ in asciicast v3 format. Recordings can be played back
@@ -458,6 +459,45 @@ the shell script. Restart your shell after uninstalling.
 
 EXAMPLE:
     agr shell uninstall
+```
+
+---
+
+## agr optimize
+
+Optimize asciicast recordings (removes silence)
+
+### Arguments
+
+- `<FILE>`: Path to the .cast recording file
+
+### Options
+
+- `--remove-silence`: Cap intervals at threshold (default: header or 2.0s)
+- `-o, --output`: Output file path
+
+### Description
+
+```
+Optimize asciicast recording files by removing silence.
+
+Optimization modifies the timing of recordings by capping long pauses
+at a configurable threshold.
+
+THRESHOLD RESOLUTION:
+    1. CLI argument (explicit user intent)
+    2. Header's idle_time_limit (recording author's intent)
+    3. Default: 2.0 seconds
+
+EXAMPLES:
+    agr optimize --remove-silence session.cast
+        Use header's idle_time_limit or default 2.0s threshold
+
+    agr optimize --remove-silence=1.5 session.cast
+        Use explicit 1.5s threshold (note: requires = for value)
+
+    agr optimize --remove-silence --output fast.cast session.cast
+        Write to separate file, preserving original
 ```
 
 ---

--- a/docs/man/agr-optimize.1
+++ b/docs/man/agr-optimize.1
@@ -1,0 +1,40 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH optimize 1  "optimize " 
+.SH NAME
+optimize \- Optimize asciicast recordings (removes silence)
+.SH SYNOPSIS
+\fBoptimize\fR [\fB\-\-remove\-silence\fR] [\fB\-o\fR|\fB\-\-output\fR] [\fB\-h\fR|\fB\-\-help\fR] <\fIFILE\fR> 
+.SH DESCRIPTION
+Optimize asciicast recording files by removing silence.
+.PP
+Optimization modifies the timing of recordings by capping long pauses
+at a configurable threshold.
+.PP
+THRESHOLD RESOLUTION:
+    1. CLI argument (explicit user intent)
+    2. Header\*(Aqs idle_time_limit (recording author\*(Aqs intent)
+    3. Default: 2.0 seconds
+.PP
+EXAMPLES:
+    agr optimize \-\-remove\-silence session.cast
+        Use header\*(Aqs idle_time_limit or default 2.0s threshold
+.PP
+    agr optimize \-\-remove\-silence=1.5 session.cast
+        Use explicit 1.5s threshold (note: requires = for value)
+.PP
+    agr optimize \-\-remove\-silence \-\-output fast.cast session.cast
+        Write to separate file, preserving original
+.SH OPTIONS
+.TP
+\fB\-\-remove\-silence\fR[=\fI<SECONDS>\fR]
+Cap intervals at threshold (default: header or 2.0s)
+.TP
+\fB\-o\fR, \fB\-\-output\fR \fI<FILE>\fR
+Output file path
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+<\fIFILE\fR>
+Path to the .cast recording file

--- a/docs/man/agr.1
+++ b/docs/man/agr.1
@@ -2,11 +2,11 @@
 .el .ds Aq '
 .TH agr 1  "agr 0.1.0" 
 .SH NAME
-agr \- [ Agent Session Recorder ] \- auto\-record agent sessions and handle the recordings with AI!
+agr \- [ Agent Session Recorder ] \- Record, replay, and understand AI agent sessions.
 .SH SYNOPSIS
 \fBagr\fR [\fB\-h\fR|\fB\-\-help\fR] [\fB\-V\fR|\fB\-\-version\fR] <\fIsubcommands\fR>
 .SH DESCRIPTION
-Agent Session Recorder (AGR) \- Record AI agent terminal sessions with asciinema.
+[ Agent Session Recorder ] \- Record, replay, and understand AI agent sessions.
 .PP
 AGR automatically records your AI coding agent sessions (Claude, Codex, Gemini, etc.)
 to ~/recorded_agent_sessions/ in asciicast v3 format. Recordings can be played back
@@ -58,6 +58,9 @@ Configuration management
 .TP
 agr\-shell(1)
 Manage shell integration
+.TP
+agr\-optimize(1)
+Optimize asciicast recordings (removes silence)
 .TP
 agr\-help(1)
 Print this message or the help of the given subcommand(s)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -25,11 +25,9 @@ pub fn build_cli_styles() -> Styles {
 
 #[derive(Parser)]
 #[command(name = "agr")]
+#[command(about = "[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.")]
 #[command(
-    about = "[ Agent Session Recorder ] - auto-record agent sessions and handle the recordings with AI!"
-)]
-#[command(
-    long_about = "Agent Session Recorder (AGR) - Record AI agent terminal sessions with asciinema.
+    long_about = "[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.
 
 AGR automatically records your AI coding agent sessions (Claude, Codex, Gemini, etc.)
 to ~/recorded_agent_sessions/ in asciicast v3 format. Recordings can be played back

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
@@ -15,7 +15,7 @@ Exit code: 0
 [92m ⏺ REC [0m[90m─────────────────────────────────────────────────────────────────────────[0m
 
 
-Agent Session Recorder (AGR) - Record AI agent terminal sessions with asciinema.
+[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.
 
 AGR automatically records your AI coding agent sessions (Claude, Codex, Gemini, etc.)
 to ~/recorded_agent_sessions/ in asciicast v3 format. Recordings can be played back

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
@@ -15,7 +15,7 @@ ESC[92m╚═╝  ╚═╝ ╚═════╝ ╚═╝  ╚═╝ESC[0m
 ESC[92m ⏺ REC ESC[0mESC[90m─────────────────────────────────────────────────────────────────────────ESC[0m
 
 
-Agent Session Recorder (AGR) - Record AI agent terminal sessions with asciinema.
+[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.
 
 AGR automatically records your AI coding agent sessions (Claude, Codex, Gemini, etc.)
 to ~/recorded_agent_sessions/ in asciicast v3 format. Recordings can be played back

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
@@ -15,7 +15,7 @@ Exit code: 2
 [92m ⏺ REC [0m[90m─────────────────────────────────────────────────────────────────────────[0m
 
 
-[ Agent Session Recorder ] - auto-record agent sessions and handle the recordings with AI!
+[ Agent Session Recorder ] - Record, replay, and understand AI agent sessions.
 
 Usage: agr <COMMAND>
 


### PR DESCRIPTION
## Summary

- Updated slogan to "Record, replay, and understand AI agent sessions"
- Fixed outdated command references: `transform` → `optimize`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `agr optimize` command with manual pages, usage examples, and available options
  * Updated main command descriptions and help text to reflect enhanced capabilities
  * Expanded CLI documentation with new subcommand reference

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->