### PR TITLE
feat(cli): add play command for direct recording playback

### DIFF
--- a/.state/INDEX.md
+++ b/.state/INDEX.md
@@ -33,6 +33,7 @@ git log --oneline -5
 **Current focus:** None (phase complete)
 
 **Recently completed:**
+- Play command for direct recording playback (PR #81)
 - Release workflow and changelog automation (PR #75)
 - Terminal scroll region support (PR #73)
 - Terminal module re-export cleanup (PR #74)
@@ -43,6 +44,7 @@ Historical context for all state directories:
 
 | Directory | Description |
 |-----------|-------------|
+| feature-play-command | Play command for direct recording playback |
 | silence-removal | Silence/pause removal for recordings |
 | fix-player-scroll-region-bug | Terminal scroll region support in player |
 | refactor-terminal-module-cleanup | Terminal module code organization |

--- a/.state/feature-play-command/ADR.md
+++ b/.state/feature-play-command/ADR.md
@@ -1,0 +1,107 @@
+# ADR: Play Command
+
+## Status
+Accepted
+
+## Context
+
+Users cannot directly play a specific recording file without navigating through the `ls` interface. The native player has powerful capabilities (speed control, seeking, marker navigation) but these are undocumented and only accessible through the TUI.
+
+The requirements call for:
+1. A simple `agr play <filepath>` command
+2. Documentation of player capabilities in README
+3. Reusing the existing native player as-is (no new features)
+
+### Technical Context
+
+The codebase already has:
+- `player::play_session(path)` - main entry point in `src/player/native.rs`
+- `resolve_file_path()` - path resolution supporting absolute, short format (`agent/file.cast`), and fuzzy matching
+- Established command patterns in `src/commands/*.rs`
+
+All existing file-based commands (`analyze`, `marker`, `optimize`) use `resolve_file_path()` for consistency.
+
+## Options Considered
+
+### Option 1: Minimal Command (Recommended)
+
+Add `play` as a simple command that takes a filepath and directly invokes the native player.
+
+- **Pros:**
+  - Simplest implementation (~50 LOC)
+  - Follows existing command patterns exactly
+  - Minimal surface area for bugs
+  - Fast to implement and test
+
+- **Cons:**
+  - No room for future expansion without refactoring (acceptable per requirements)
+
+### Option 2: Command with Speed Option
+
+Add a `--speed` flag to let users start playback at a different speed.
+
+- **Pros:**
+  - More useful for reviewing long recordings quickly
+
+- **Cons:**
+  - Out of scope ("reuses existing native player as-is")
+  - Would require modifying native player or using asciinema fallback
+  - Scope creep
+
+### Option 3: Command with Player Choice
+
+Add `--native` / `--asciinema` flags to choose which player.
+
+- **Pros:**
+  - Flexibility for users with preferences
+
+- **Cons:**
+  - Exposes implementation detail (two players exist)
+  - Confusing UX - why two players?
+  - Out of scope
+
+## Decision
+
+**Option 1: Minimal Command**
+
+This option:
+1. Matches requirements exactly - "reuses existing native player as-is"
+2. Follows established patterns from `analyze`, `marker`, `optimize` commands
+3. Keeps the native player's complexity encapsulated
+4. Focuses effort on documentation (the higher-value deliverable)
+
+### Path Handling
+
+Use `resolve_file_path()` for consistency with other commands. This supports:
+- Absolute paths: `/full/path/to/file.cast`
+- Short format: `claude/session.cast` (relative to storage directory)
+- Filename only: `session.cast` (fuzzy match across agents)
+
+### Error Messages
+
+Follow the pattern from `analyze` and `optimize`:
+```
+File not found: <user-provided-path>
+Hint: Use format 'agent/file.cast'. Run 'agr list' to see available sessions.
+```
+
+## Consequences
+
+### What becomes easier
+- Quick playback of known recordings without TUI navigation
+- Scripting and automation of playback
+- Discoverability of player features via documentation
+
+### What becomes harder
+- Nothing significant
+
+### Follow-ups to scope for later
+- Speed control option (if user demand emerges)
+- Jump-to-marker option
+- Integration with `fzf` or similar for fuzzy file selection
+
+## Decision History
+
+1. **Option 1 selected** - User agreed with minimal command approach for simplicity and scope adherence.
+2. **Path handling** - Use `resolve_file_path()` for consistency with other commands (supports short format `agent/file.cast`).
+3. **Error messaging** - Follow existing pattern with hint to use `agr list`.

--- a/.state/feature-play-command/PLAN.md
+++ b/.state/feature-play-command/PLAN.md
@@ -1,0 +1,121 @@
+# Plan: Play Command
+
+References: ADR.md
+
+## Open Questions
+
+Implementation challenges to solve (architect identifies, implementer resolves):
+
+1. Should the play command validate `.cast` extension or accept any file? Other commands warn but proceed - follow same pattern.
+2. How should the command handle player errors (e.g., corrupt file)? The native player already has error handling - let it propagate naturally.
+
+## Stages
+
+### Stage 1: CLI Command Definition
+
+Goal: Add the `play` subcommand to the CLI with proper help text
+
+- [x] Add `Play { file: String }` variant to `Commands` enum in `src/cli.rs`
+- [x] Add appropriate help text and examples matching other commands
+- [x] Verify `agr play --help` displays correctly
+
+Files: `src/cli.rs`
+
+Considerations:
+- Match the style of existing commands (analyze, marker, optimize)
+- Include example in long_about showing `agr play claude/session.cast`
+
+### Stage 2: Command Handler
+
+Goal: Implement the play command handler that invokes the native player
+
+- [x] Create `src/commands/play.rs` with `handle(file: &str)` function
+- [x] Use `resolve_file_path()` for path resolution
+- [x] Add existence check with helpful error message
+- [x] Add `.cast` extension warning (match other commands)
+- [x] Call `player::play_session(path)`
+- [x] Export module in `src/commands/mod.rs`
+
+Files: `src/commands/play.rs`, `src/commands/mod.rs`
+
+Considerations:
+- Follow the exact pattern from `analyze.rs` for consistency
+- Error message should include hint about `agr list`
+- Player handles its own cleanup (terminal restore, etc.)
+
+### Stage 3: Main Dispatch
+
+Goal: Wire up the command in main.rs
+
+- [x] Add match arm for `Commands::Play` in `main.rs`
+- [x] Call `commands::play::handle()`
+
+Files: `src/main.rs`
+
+Considerations:
+- Simple dispatch, no special handling needed
+- Player manages terminal state internally
+
+### Stage 4: Integration Tests
+
+Goal: Verify command works end-to-end
+
+- [x] Test: `agr play --help` shows usage
+- [x] Test: `agr play nonexistent.cast` shows error with hint
+- [x] Test: `agr play` without arguments shows usage/error
+- [x] Test: Path resolution works (short format `agent/file.cast`)
+
+Files: `tests/integration/play_test.rs` or extend existing CLI tests
+
+Considerations:
+- Cannot easily test actual playback (requires terminal interaction)
+- Focus on argument parsing, path resolution, error handling
+- Use existing test helpers for temp files
+
+### Stage 5: Documentation Updates
+
+Goal: Update README with play command and player capabilities
+
+- [x] Add `agr play` to quick start section in README
+- [x] Document native player controls in a new section or table:
+  - `q` / `Esc` - Quit
+  - `Space` - Pause/resume
+  - `+` / `-` - Speed up/down
+  - `<` / `>` - Seek back/forward 5s
+  - `m` - Jump to next marker
+  - `?` - Show help overlay
+- [x] Update command reference if auto-generated (run `cargo xtask gen-docs`)
+- [x] Add play command to wiki if applicable
+
+Files: `README.md`, `docs/COMMANDS.md` (via xtask)
+
+Considerations:
+- Keep quick start concise - just show the command exists
+- Player controls can be a dedicated subsection
+- Verify controls by checking `src/player/native.rs` help overlay
+
+## Dependencies
+
+```
+Stage 1 ──> Stage 2 ──> Stage 3 ──> Stage 4
+                                      │
+                                      v
+                                   Stage 5
+```
+
+- Stage 2 depends on Stage 1 (needs CLI definition)
+- Stage 3 depends on Stage 2 (needs handler)
+- Stage 4 depends on Stage 3 (needs working command)
+- Stage 5 can start after Stage 3 but should verify with Stage 4
+
+## Progress
+
+Updated by implementer as work progresses.
+
+| Stage | Status | Notes |
+|-------|--------|-------|
+| 1 | complete | CLI command definition added to src/cli.rs |
+| 2 | complete | Handler created in src/commands/play.rs |
+| 3 | complete | Match arm added in main.rs |
+| 4 | complete | Tests in tests/integration/play_test.rs and main.rs |
+| 5 | complete | README updated, docs regenerated |

--- a/.state/feature-play-command/REQUIREMENTS.md
+++ b/.state/feature-play-command/REQUIREMENTS.md
@@ -1,0 +1,26 @@
+# Requirements: Play Command
+
+## Problem Statement
+Users cannot directly play a specific recording file without navigating through the `ls` interface. Additionally, the native player's powerful capabilities (speed control, navigation shortcuts) are underemphasized in documentation, leaving users unaware of available features.
+
+## User Stories
+- As a user, I want to play a recording file directly by path so that I can quickly view a specific session without browsing through listings
+- As a new user, I want to see the play command in the quick start guide so that I can immediately understand how to view recordings
+- As a user, I want to discover the native player's capabilities (speedup, jump forward/back) in the documentation so that I can efficiently navigate recordings
+
+## Acceptance Criteria
+- [ ] `asr play <filepath>` command plays the specified `.cast` file using the native player
+- [ ] Running `asr play` without arguments displays usage help
+- [ ] Running `asr play` with a non-existent file shows a clear error message
+- [ ] README quick start section includes the `play` command with a basic example
+- [ ] README documents native player capabilities: speed control, jump forward/back, and any other navigation shortcuts
+- [ ] `asr play --help` shows command description and usage
+
+## Out of Scope
+- Playing recordings by ID or name (only filepath supported)
+- Interactive selection/browsing (use `ls` for that)
+- Adding new player features (reuses existing native player as-is)
+- Changes to the `ls` command behavior
+
+## Sign-off
+- [x] User approved

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ agr list
 # Check storage usage:
 agr status
 
-# Play back a recording:
-asciinema play ~/recorded_agent_sessions/claude/session.cast
+# Play back a recording with the native player:
+agr play session.cast
 
 # Remove long pauses from a recording (e.g., lunch breaks):
 agr optimize --remove-silence session.cast
@@ -76,6 +76,37 @@ agr optimize --remove-silence session.cast
 # Add a marker to highlight an important moment:
 agr marker add session.cast 45.2 "Build failed - missing dependency"
 ```
+
+## Playing Recordings
+
+AGR includes a native player with seeking, speed control, and marker navigation.
+
+```bash
+# Play by filename (fuzzy matches across agents)
+agr play session.cast
+
+# Play using short format
+agr play claude/session.cast
+
+# Play by absolute path
+agr play ~/recorded_agent_sessions/claude/session.cast
+```
+
+### Player Controls
+
+| Key | Action |
+|-----|--------|
+| `Space` | Pause / Resume |
+| `+` / `-` | Adjust playback speed |
+| `<` / `>` or `,` / `.` | Seek backward/forward 5s |
+| `Home` / `End` | Go to start/end |
+| `m` | Jump to next marker |
+| `v` | Toggle viewport mode (for large recordings) |
+| `r` | Resize terminal to match recording |
+| `?` | Show help overlay |
+| `q` / `Esc` | Quit player |
+
+**Viewport Mode**: When the recording is larger than your terminal, press `v` to enter viewport mode. Use arrow keys to scroll around the recording, and press `Esc` to exit viewport mode.
 
 ## Post-Processing Recordings
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -9,6 +9,7 @@ This document is auto-generated from the CLI definitions.
 - [cleanup](#agr-cleanup)
 - [list](#agr-list)
 - [analyze](#agr-analyze)
+- [play](#agr-play)
 - [marker](#agr-marker)
 - [agents](#agr-agents)
 - [config](#agr-config)
@@ -186,6 +187,39 @@ SUPPORTED AGENTS:
     claude      Claude Code CLI
     codex       OpenAI Codex CLI
     gemini  Google Gemini CLI
+```
+
+---
+
+## agr play
+
+Play a recording with the native player
+
+### Arguments
+
+- `<FILE>`: Path to the .cast recording file
+
+### Description
+
+```
+Play an asciicast recording using the native player.
+
+The native player supports seeking, speed control, and marker navigation.
+Recordings can be specified by absolute path, short format (agent/file.cast),
+or just filename (fuzzy matches across all agents).
+
+EXAMPLES:
+    agr play session.cast                 Play by filename (fuzzy match)
+    agr play claude/session.cast          Play using short format
+    agr play /path/to/session.cast        Play by absolute path
+
+PLAYER CONTROLS:
+    q, Esc      Quit
+    Space       Pause/resume
+    +/-         Adjust playback speed
+    <, >        Seek backward/forward 5s
+    m           Jump to next marker
+    ?           Show help overlay
 ```
 
 ---

--- a/docs/man/agr-play.1
+++ b/docs/man/agr-play.1
@@ -1,0 +1,33 @@
+.ie \n(.g .ds Aq \(aq
+.el .ds Aq '
+.TH play 1  "play " 
+.SH NAME
+play \- Play a recording with the native player
+.SH SYNOPSIS
+\fBplay\fR [\fB\-h\fR|\fB\-\-help\fR] <\fIFILE\fR> 
+.SH DESCRIPTION
+Play an asciicast recording using the native player.
+.PP
+The native player supports seeking, speed control, and marker navigation.
+Recordings can be specified by absolute path, short format (agent/file.cast),
+or just filename (fuzzy matches across all agents).
+.PP
+EXAMPLES:
+    agr play session.cast                 Play by filename (fuzzy match)
+    agr play claude/session.cast          Play using short format
+    agr play /path/to/session.cast        Play by absolute path
+.PP
+PLAYER CONTROLS:
+    q, Esc      Quit
+    Space       Pause/resume
+    +/\-         Adjust playback speed
+    <, >        Seek backward/forward 5s
+    m           Jump to next marker
+    ?           Show help overlay
+.SH OPTIONS
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Print help (see a summary with \*(Aq\-h\*(Aq)
+.TP
+<\fIFILE\fR>
+Path to the .cast recording file

--- a/docs/man/agr.1
+++ b/docs/man/agr.1
@@ -47,6 +47,9 @@ List recorded sessions
 agr\-analyze(1)
 Analyze a recording with AI
 .TP
+agr\-play(1)
+Play a recording with the native player
+.TP
 agr\-marker(1)
 Manage markers in cast files
 .TP

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -185,7 +185,7 @@ PLAYER CONTROLS:
     q, Esc      Quit
     Space       Pause/resume
     +/-         Adjust playback speed
-    <, >        Seek backward/forward 5s
+    <, > or ,, .  Seek backward/forward 5s
     m           Jump to next marker
     ?           Show help overlay")]
     Play {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -169,6 +169,31 @@ SUPPORTED AGENTS:
         agent: Option<String>,
     },
 
+    /// Play a recording with the native player
+    #[command(long_about = "Play an asciicast recording using the native player.
+
+The native player supports seeking, speed control, and marker navigation.
+Recordings can be specified by absolute path, short format (agent/file.cast),
+or just filename (fuzzy matches across all agents).
+
+EXAMPLES:
+    agr play session.cast                 Play by filename (fuzzy match)
+    agr play claude/session.cast          Play using short format
+    agr play /path/to/session.cast        Play by absolute path
+
+PLAYER CONTROLS:
+    q, Esc      Quit
+    Space       Pause/resume
+    +/-         Adjust playback speed
+    <, >        Seek backward/forward 5s
+    m           Jump to next marker
+    ?           Show help overlay")]
+    Play {
+        /// Path to the .cast file to play
+        #[arg(help = "Path to the .cast recording file")]
+        file: String,
+    },
+
     /// Manage markers in cast files
     #[command(
         subcommand,

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -10,6 +10,7 @@ pub mod completions;
 pub mod config;
 pub mod list;
 pub mod marker;
+pub mod play;
 pub mod record;
 pub mod shell;
 pub mod status;

--- a/src/commands/play.rs
+++ b/src/commands/play.rs
@@ -1,0 +1,35 @@
+//! Play command handler
+
+use anyhow::Result;
+
+use agr::{play_session, Config};
+
+use super::resolve_file_path;
+
+/// Play a recording file using the native player.
+///
+/// Resolves the file path and invokes the native player for playback.
+/// Supports absolute paths, short format (agent/file.cast), and fuzzy matching.
+#[cfg(not(tarpaulin_include))]
+pub fn handle(file: &str) -> Result<()> {
+    let config = Config::load()?;
+
+    // Resolve file path (supports short format like "claude/session.cast")
+    let filepath = resolve_file_path(file, &config)?;
+    if !filepath.exists() {
+        anyhow::bail!(
+            "File not found: {}\nHint: Use format 'agent/file.cast'. Run 'agr list' to see available sessions.",
+            file
+        );
+    }
+
+    // Check file has .cast extension
+    if filepath.extension().and_then(|e| e.to_str()) != Some("cast") {
+        eprintln!("Warning: File does not have .cast extension");
+    }
+
+    // Play the session using the native player
+    let result = play_session(&filepath)?;
+    println!("{}", result.message());
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,6 +293,7 @@ fn main() -> Result<()> {
         }
         Commands::List { agent } => commands::list::handle(agent.as_deref()),
         Commands::Analyze { file, agent } => commands::analyze::handle(&file, agent.as_deref()),
+        Commands::Play { file } => commands::play::handle(&file),
         Commands::Marker(cmd) => match cmd {
             MarkerCommands::Add { file, time, label } => {
                 commands::marker::handle_add(&file, time, &label)
@@ -708,6 +709,39 @@ mod tests {
         match cli.command {
             Commands::Status => {}
             _ => panic!("Expected Status command"),
+        }
+    }
+
+    #[test]
+    fn cli_play_parses_with_file() {
+        let cli = Cli::try_parse_from(["agr", "play", "session.cast"]).unwrap();
+        match cli.command {
+            Commands::Play { file } => {
+                assert_eq!(file, "session.cast");
+            }
+            _ => panic!("Expected Play command"),
+        }
+    }
+
+    #[test]
+    fn cli_play_parses_with_path() {
+        let cli = Cli::try_parse_from(["agr", "play", "/path/to/session.cast"]).unwrap();
+        match cli.command {
+            Commands::Play { file } => {
+                assert_eq!(file, "/path/to/session.cast");
+            }
+            _ => panic!("Expected Play command"),
+        }
+    }
+
+    #[test]
+    fn cli_play_parses_with_short_format() {
+        let cli = Cli::try_parse_from(["agr", "play", "claude/session.cast"]).unwrap();
+        match cli.command {
+            Commands::Play { file } => {
+                assert_eq!(file, "claude/session.cast");
+            }
+            _ => panic!("Expected Play command"),
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -33,6 +33,9 @@ mod snapshot_tui_test;
 #[path = "integration/snapshot_cli_test.rs"]
 mod snapshot_cli_test;
 
+#[path = "integration/play_test.rs"]
+mod play_test;
+
 #[path = "integration/preview_test.rs"]
 mod preview_test;
 

--- a/tests/integration/play_test.rs
+++ b/tests/integration/play_test.rs
@@ -118,7 +118,7 @@ fn play_warns_for_non_cast_extension() {
 
     // Should show warning about extension (written to stderr)
     assert!(
-        stderr.contains("Warning") || stderr.contains(".cast"),
+        stderr.contains("Warning: File does not have .cast extension"),
         "Should warn about non-.cast extension"
     );
 }

--- a/tests/integration/play_test.rs
+++ b/tests/integration/play_test.rs
@@ -1,0 +1,141 @@
+//! Integration tests for the play command
+
+use std::process::Command;
+use tempfile::TempDir;
+
+use crate::helpers::{fixtures_dir, load_fixture};
+
+/// Helper to run agr CLI and capture output
+fn run_agr(args: &[&str]) -> (String, String, i32) {
+    let output = Command::new(env!("CARGO_BIN_EXE_agr"))
+        .args(args)
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to execute agr");
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    (stdout, stderr, exit_code)
+}
+
+// ============================================================================
+// Help Output Tests
+// ============================================================================
+
+#[test]
+fn play_help_shows_usage() {
+    let (stdout, _stderr, exit_code) = run_agr(&["play", "--help"]);
+
+    assert_eq!(exit_code, 0);
+    assert!(stdout.contains("Play an asciicast recording"));
+    assert!(stdout.contains("<FILE>"));
+    assert!(stdout.contains("PLAYER CONTROLS"));
+    assert!(stdout.contains("Space"));
+    assert!(stdout.contains("Pause/resume"));
+}
+
+#[test]
+fn snapshot_cli_help_play() {
+    let (stdout, stderr, exit_code) = run_agr(&["play", "--help"]);
+    let output = format!(
+        "=== agr play --help ===\nExit code: {}\n\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        exit_code, stdout, stderr
+    );
+    insta::assert_snapshot!("cli_help_play", output);
+}
+
+// ============================================================================
+// Error Handling Tests
+// ============================================================================
+
+#[test]
+fn play_no_arguments_shows_error() {
+    let (_stdout, stderr, exit_code) = run_agr(&["play"]);
+
+    assert_eq!(exit_code, 2);
+    assert!(stderr.contains("required arguments"));
+    assert!(stderr.contains("<FILE>"));
+}
+
+#[test]
+fn play_nonexistent_file_shows_error() {
+    let (_stdout, stderr, exit_code) = run_agr(&["play", "nonexistent.cast"]);
+
+    assert_eq!(exit_code, 1);
+    assert!(stderr.contains("File not found"));
+    assert!(stderr.contains("nonexistent.cast"));
+    assert!(stderr.contains("agr list"));
+}
+
+#[test]
+fn play_nonexistent_file_with_path_shows_error() {
+    let (_stdout, stderr, exit_code) = run_agr(&["play", "/some/path/to/missing.cast"]);
+
+    assert_eq!(exit_code, 1);
+    assert!(stderr.contains("File not found"));
+}
+
+// ============================================================================
+// Path Resolution Tests
+// ============================================================================
+
+#[test]
+fn play_with_absolute_path_exists_check() {
+    // Create a temp file
+    let temp_dir = TempDir::new().unwrap();
+    let cast_path = temp_dir.path().join("test.cast");
+    std::fs::write(&cast_path, load_fixture("sample.cast")).unwrap();
+
+    // Try to play it - we can't test actual playback without a TTY,
+    // but we can verify it doesn't fail with "File not found"
+    let (_stdout, stderr, _exit_code) = run_agr(&["play", cast_path.to_str().unwrap()]);
+
+    // Should NOT show "File not found" error
+    assert!(
+        !stderr.contains("File not found"),
+        "Should find file at absolute path"
+    );
+
+    // It might fail for other reasons (no TTY) but that's OK
+    // The important thing is that the file was found
+}
+
+// Note: Short format resolution is tested at the unit level in src/commands/mod.rs
+// via resolve_file_path_tests. Integration tests cannot easily override the storage
+// directory without config file manipulation.
+
+#[test]
+fn play_warns_for_non_cast_extension() {
+    // Create a temp file with wrong extension
+    let temp_dir = TempDir::new().unwrap();
+    let file_path = temp_dir.path().join("test.txt");
+    std::fs::write(&file_path, load_fixture("sample.cast")).unwrap();
+
+    // Try to play it
+    let (_stdout, stderr, _exit_code) = run_agr(&["play", file_path.to_str().unwrap()]);
+
+    // Should show warning about extension (written to stderr)
+    assert!(
+        stderr.contains("Warning") || stderr.contains(".cast"),
+        "Should warn about non-.cast extension"
+    );
+}
+
+// ============================================================================
+// CLI Parsing Tests (in main.rs, but we verify here)
+// ============================================================================
+
+#[test]
+fn play_accepts_file_argument() {
+    // Just verify the command parses correctly
+    let fixture_path = fixtures_dir().join("sample.cast");
+    let (_stdout, stderr, _exit_code) = run_agr(&["play", fixture_path.to_str().unwrap()]);
+
+    // Should NOT show parsing errors
+    assert!(
+        !stderr.contains("unexpected argument"),
+        "Command should parse file argument correctly"
+    );
+}

--- a/tests/integration/snapshots/integration__play_test__cli_help_play.snap
+++ b/tests/integration/snapshots/integration__play_test__cli_help_play.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration/play_test.rs
-assertion_line: 62
+assertion_line: 46
 expression: output
 ---
 === agr play --help ===
@@ -22,7 +22,7 @@ PLAYER CONTROLS:
     q, Esc      [37mQuit[0m
     Space       [37mPause/resume[0m
     +/-         [37mAdjust playback speed[0m
-    <, >        Seek backward/forward 5s
+    <, > or ,, .  Seek backward/forward 5s
     m           [37mJump to next marker[0m
     ?           [37mShow help overlay[0m
 

--- a/tests/integration/snapshots/integration__play_test__cli_help_play.snap
+++ b/tests/integration/snapshots/integration__play_test__cli_help_play.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration/play_test.rs
+assertion_line: 62
+expression: output
+---
+=== agr play --help ===
+Exit code: 0
+
+--- stdout ---
+Play an asciicast recording using the native player.
+
+The native player supports seeking, speed control, and marker navigation.
+Recordings can be specified by absolute path, short format (agent/file.cast),
+or just filename (fuzzy matches across all agents).
+
+EXAMPLES:
+    agr play session.cast                 [37mPlay by filename (fuzzy match)[0m
+    agr play claude/session.cast          [37mPlay using short format[0m
+    agr play /path/to/session.cast        [37mPlay by absolute path[0m
+
+PLAYER CONTROLS:
+    q, Esc      [37mQuit[0m
+    Space       [37mPause/resume[0m
+    +/-         [37mAdjust playback speed[0m
+    <, >        Seek backward/forward 5s
+    m           [37mJump to next marker[0m
+    ?           [37mShow help overlay[0m
+
+Usage: agr play <FILE>
+
+Arguments:
+  <FILE>
+          Path to the .cast recording file
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
+--- stderr ---

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration/snapshot_cli_test.rs
+assertion_line: 49
 expression: output
 ---
 === agr --help ===
@@ -41,6 +42,7 @@ Commands:
   cleanup   [37mInteractive cleanup of old sessions[0m
   list      [37mList recorded sessions [aliases: ls][0m
   analyze   [37mAnalyze a recording with AI[0m
+  play      [37mPlay a recording with the native player[0m
   marker    [37mManage markers in cast files[0m
   agents    [37mManage configured agents[0m
   config    [37mConfiguration management[0m

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration/snapshot_cli_test.rs
+assertion_line: 205
 expression: output
 ---
 === agr --help (colored) ===
@@ -41,6 +42,7 @@ Commands:
   cleanup   ESC[37mInteractive cleanup of old sessionsESC[0m
   list      ESC[37mList recorded sessions [aliases: ls]ESC[0m
   analyze   ESC[37mAnalyze a recording with AIESC[0m
+  play      ESC[37mPlay a recording with the native playerESC[0m
   marker    ESC[37mManage markers in cast filesESC[0m
   agents    ESC[37mManage configured agentsESC[0m
   config    ESC[37mConfiguration managementESC[0m

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration/snapshot_cli_test.rs
+assertion_line: 153
 expression: output
 ---
 === agr (no args) ===
@@ -25,6 +26,7 @@ Commands:
   cleanup   [37mInteractive cleanup of old sessions[0m
   list      [37mList recorded sessions [aliases: ls][0m
   analyze   [37mAnalyze a recording with AI[0m
+  play      [37mPlay a recording with the native player[0m
   marker    [37mManage markers in cast files[0m
   agents    [37mManage configured agents[0m
   config    [37mConfiguration management[0m


### PR DESCRIPTION
## Summary

- Add new `agr play <file>` command to directly play recordings without TUI navigation
- Support absolute paths, short format (agent/file.cast), and fuzzy filename matching
- Document native player controls in README with new "Playing Recordings" section

## Changes

- `src/cli.rs`: Add `Play { file: String }` variant to Commands enum with help text
- `src/commands/play.rs`: New handler using `resolve_file_path()` and `play_session()`
- `src/commands/mod.rs`: Export play module
- `src/main.rs`: Add match arm for Play command, plus CLI parsing tests
- `tests/integration/play_test.rs`: Integration tests for help, errors, path resolution
- `README.md`: Add "Playing Recordings" section with player controls table
- `docs/`: Regenerated man pages and COMMANDS.md

## Test plan

- [x] `cargo fmt` - passes
- [x] `cargo clippy` - passes
- [x] `cargo test` - all 356+ tests pass
- [x] `./tests/e2e_test.sh` - all 77 E2E tests pass
- [x] `cargo build --release` - builds successfully
- [x] Manual verification: `agr play --help` shows usage
- [x] Manual verification: `agr play nonexistent.cast` shows helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `agr play` command to play recordings with the native player, supporting absolute paths, short-format paths, and fuzzy filename matching with playback controls

* **Documentation**
  * Added comprehensive documentation for the play command in COMMANDS.md and dedicated man page with usage examples and player controls reference

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->