### PR TITLE
refactor: rename status command to usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ agr record claude
 agr list
 
 # Check storage usage:
-agr status
+agr usage
 
 # Play back a recording with the native player:
 agr play session.cast

--- a/agents/skills/instructions/references/commands.md
+++ b/agents/skills/instructions/references/commands.md
@@ -5,7 +5,7 @@
 ```
 agr record <agent> [-- args...]      # Start recording session
 agr analyze <file> [--agent <name>]  # Analyze recording with AI
-agr status                           # Show storage stats
+agr usage                            # Show storage stats
 agr cleanup                          # Interactive cleanup
 agr list [agent]                     # List sessions
 agr marker add <file> <time> <label> # Add marker

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -5,7 +5,7 @@ This document is auto-generated from the CLI definitions.
 ## Table of Contents
 
 - [record](#agr-record)
-- [status](#agr-status)
+- [usage](#agr-usage)
 - [cleanup](#agr-cleanup)
 - [list](#agr-list)
 - [analyze](#agr-analyze)
@@ -31,7 +31,7 @@ with asciinema, auto-analyzed by AI agents, and annotated with markers.
 
 QUICK START:
     agr record claude              Record a Claude session
-    agr status                     Check storage usage
+    agr usage                      Check storage usage
     agr list                       List all recordings
     agr cleanup                    Clean up old recordings
 
@@ -74,7 +74,7 @@ EXAMPLES:
 
 ---
 
-## agr status
+## agr usage
 
 Show storage statistics
 
@@ -87,7 +87,7 @@ Shows total size, disk usage percentage, session count by agent,
 and age of the oldest recording.
 
 EXAMPLE:
-    agr status
+    agr usage
 
 OUTPUT:
     Agent Sessions: 1.2 GB (0.5% of disk)
@@ -217,7 +217,7 @@ PLAYER CONTROLS:
     q, Esc      Quit
     Space       Pause/resume
     +/-         Adjust playback speed
-    <, >        Seek backward/forward 5s
+    <, > or ,, .  Seek backward/forward 5s
     m           Jump to next marker
     ?           Show help overlay
 ```

--- a/docs/man/agr-play.1
+++ b/docs/man/agr-play.1
@@ -21,7 +21,7 @@ PLAYER CONTROLS:
     q, Esc      Quit
     Space       Pause/resume
     +/\-         Adjust playback speed
-    <, >        Seek backward/forward 5s
+    <, > or ,, .  Seek backward/forward 5s
     m           Jump to next marker
     ?           Show help overlay
 .SH OPTIONS

--- a/docs/man/agr-usage.1
+++ b/docs/man/agr-usage.1
@@ -1,10 +1,10 @@
 .ie \n(.g .ds Aq \(aq
 .el .ds Aq '
-.TH status 1  "status " 
+.TH usage 1  "usage " 
 .SH NAME
-status \- Show storage statistics
+usage \- Show storage statistics
 .SH SYNOPSIS
-\fBstatus\fR [\fB\-h\fR|\fB\-\-help\fR] 
+\fBusage\fR [\fB\-h\fR|\fB\-\-help\fR] 
 .SH DESCRIPTION
 Display storage statistics for recorded sessions.
 .PP
@@ -12,7 +12,7 @@ Shows total size, disk usage percentage, session count by agent,
 and age of the oldest recording.
 .PP
 EXAMPLE:
-    agr status
+    agr usage
 .PP
 OUTPUT:
     Agent Sessions: 1.2 GB (0.5% of disk)

--- a/docs/man/agr.1
+++ b/docs/man/agr.1
@@ -14,7 +14,7 @@ with asciinema, auto\-analyzed by AI agents, and annotated with markers.
 .PP
 QUICK START:
     agr record claude              Record a Claude session
-    agr status                     Check storage usage
+    agr usage                      Check storage usage
     agr list                       List all recordings
     agr cleanup                    Clean up old recordings
 .PP
@@ -35,7 +35,7 @@ Print version
 agr\-record(1)
 Start recording a session
 .TP
-agr\-status(1)
+agr\-usage(1)
 Show storage statistics
 .TP
 agr\-cleanup(1)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -35,7 +35,7 @@ with asciinema, auto-analyzed by AI agents, and annotated with markers.
 
 QUICK START:
     agr record claude              Record a Claude session
-    agr status                     Check storage usage
+    agr usage                      Check storage usage
     agr list                       List all recordings
     agr cleanup                    Clean up old recordings
 
@@ -85,13 +85,13 @@ Shows total size, disk usage percentage, session count by agent,
 and age of the oldest recording.
 
 EXAMPLE:
-    agr status
+    agr usage
 
 OUTPUT:
     Agent Sessions: 1.2 GB (0.5% of disk)
        Sessions: 23 total (claude: 15, codex: 8)
        Oldest: 2025-01-01 (20 days ago)")]
-    Status,
+    Usage,
 
     /// Interactive cleanup of old sessions
     #[command(

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -13,8 +13,8 @@ pub mod marker;
 pub mod play;
 pub mod record;
 pub mod shell;
-pub mod status;
 pub mod transform;
+pub mod usage;
 
 use anyhow::Result;
 use std::path::PathBuf;

--- a/src/commands/usage.rs
+++ b/src/commands/usage.rs
@@ -1,4 +1,4 @@
-//! Status command handler
+//! Usage command handler
 
 use anyhow::Result;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ fn main() -> Result<()> {
         Commands::Record { agent, name, args } => {
             commands::record::handle(&agent, name.as_deref(), &args)
         }
-        Commands::Status => commands::status::handle(),
+        Commands::Usage => commands::usage::handle(),
         Commands::Cleanup { agent, older_than } => {
             commands::cleanup::handle(agent.as_deref(), older_than)
         }
@@ -704,11 +704,11 @@ mod tests {
     }
 
     #[test]
-    fn cli_status_parses() {
-        let cli = Cli::try_parse_from(["agr", "status"]).unwrap();
+    fn cli_usage_parses() {
+        let cli = Cli::try_parse_from(["agr", "usage"]).unwrap();
         match cli.command {
-            Commands::Status => {}
-            _ => panic!("Expected Status command"),
+            Commands::Usage => {}
+            _ => panic!("Expected Usage command"),
         }
     }
 

--- a/tests/integration/snapshot_cli_test.rs
+++ b/tests/integration/snapshot_cli_test.rs
@@ -120,13 +120,13 @@ fn snapshot_cli_help_list() {
 }
 
 #[test]
-fn snapshot_cli_help_status() {
-    let (stdout, stderr, exit_code) = run_agr(&["status", "--help"]);
+fn snapshot_cli_help_usage() {
+    let (stdout, stderr, exit_code) = run_agr(&["usage", "--help"]);
     let output = format!(
-        "=== agr status --help ===\nExit code: {}\n\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        "=== agr usage --help ===\nExit code: {}\n\n--- stdout ---\n{}\n--- stderr ---\n{}",
         exit_code, stdout, stderr
     );
-    insta::assert_snapshot!("cli_help_status", output);
+    insta::assert_snapshot!("cli_help_usage", output);
 }
 
 #[test]

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot_cli_test.rs
-assertion_line: 49
 expression: output
 ---
 === agr --help ===
@@ -24,7 +23,7 @@ with asciinema, auto-analyzed by AI agents, and annotated with markers.
 
 QUICK START:
     agr record claude              [37mRecord a Claude session[0m
-    agr status                     [37mCheck storage usage[0m
+    agr usage                      [37mCheck storage usage[0m
     agr list                       [37mList all recordings[0m
     agr cleanup                    [37mClean up old recordings[0m
 
@@ -38,7 +37,7 @@ Usage: agr <COMMAND>
 
 Commands:
   record    [37mStart recording a session[0m
-  status    [37mShow storage statistics[0m
+  usage     [37mShow storage statistics[0m
   cleanup   [37mInteractive cleanup of old sessions[0m
   list      [37mList recorded sessions [aliases: ls][0m
   analyze   [37mAnalyze a recording with AI[0m

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_main_colored.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot_cli_test.rs
-assertion_line: 205
 expression: output
 ---
 === agr --help (colored) ===
@@ -24,7 +23,7 @@ with asciinema, auto-analyzed by AI agents, and annotated with markers.
 
 QUICK START:
     agr record claude              ESC[37mRecord a Claude sessionESC[0m
-    agr status                     ESC[37mCheck storage usageESC[0m
+    agr usage                      ESC[37mCheck storage usageESC[0m
     agr list                       ESC[37mList all recordingsESC[0m
     agr cleanup                    ESC[37mClean up old recordingsESC[0m
 
@@ -38,7 +37,7 @@ Usage: agr <COMMAND>
 
 Commands:
   record    ESC[37mStart recording a sessionESC[0m
-  status    ESC[37mShow storage statisticsESC[0m
+  usage     ESC[37mShow storage statisticsESC[0m
   cleanup   ESC[37mInteractive cleanup of old sessionsESC[0m
   list      ESC[37mList recorded sessions [aliases: ls]ESC[0m
   analyze   ESC[37mAnalyze a recording with AIESC[0m

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_usage.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_help_usage.snap
@@ -1,9 +1,8 @@
 ---
-source: tests/integration/cli_test.rs
-assertion_line: 129
+source: tests/integration/snapshot_cli_test.rs
 expression: output
 ---
-=== agr status --help ===
+=== agr usage --help ===
 Exit code: 0
 
 --- stdout ---
@@ -13,14 +12,14 @@ Shows total size, disk usage percentage, session count by agent,
 and age of the oldest recording.
 
 EXAMPLE:
-    agr status
+    agr usage
 
 OUTPUT:
     Agent Sessions: 1.2 GB (0.5% of disk)
        Sessions: 23 total (claude: 15, codex: 8)
        Oldest: 2025-01-01 (20 days ago)
 
-Usage: agr status
+Usage: agr usage
 
 Options:
   -h, --help

--- a/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
+++ b/tests/integration/snapshots/integration__snapshot_cli_test__cli_no_subcommand.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration/snapshot_cli_test.rs
-assertion_line: 153
 expression: output
 ---
 === agr (no args) ===
@@ -22,7 +21,7 @@ Usage: agr <COMMAND>
 
 Commands:
   record    [37mStart recording a session[0m
-  status    [37mShow storage statistics[0m
+  usage     [37mShow storage statistics[0m
   cleanup   [37mInteractive cleanup of old sessions[0m
   list      [37mList recorded sessions [aliases: ls][0m
   analyze   [37mAnalyze a recording with AI[0m


### PR DESCRIPTION
## Summary
- Rename `status` command to `usage` throughout the codebase
- Remove `status` command entirely (no deprecation alias)
- Update all references (CLI, main.rs dispatch, mod.rs exports)
- Update tests and snapshots
- Regenerate documentation (man pages, COMMANDS.md)

## Test plan
- [x] `cargo fmt && cargo clippy && cargo test` passes
- [x] `cargo xtask gen-docs` regenerates docs
- [x] `./tests/e2e_test.sh` passes
- [x] `agr usage` command works as expected
- [x] `agr status` no longer works (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)