### PR TITLE
feat(docs): add xtask update-wiki command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ tarpaulin-report.html
 # Local agent settings (not to be committed)
 agents/settings.local.json
 docs/wiki/
+.wiki/
 .archive/


### PR DESCRIPTION
## Summary
- Add `cargo xtask update-wiki` command to automate GitHub wiki deployment
- Auto-infers wiki repo URL from git origin
- Supports `--push` for one-command wiki updates
- Adds `.wiki/` to `.gitignore`

## Test plan
- [x] `cargo build -p xtask` compiles
- [x] `cargo xtask update-wiki --help` shows options
- [x] `cargo clippy -p xtask` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)