### PR TITLE
fix(ci): use deploy key for docs workflow to bypass branch protection

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Fix docs workflow failing due to branch protection rules
- Use deploy key (`DOCS_DEPLOY_KEY`) instead of `GITHUB_TOKEN`

## Problem
The "Regenerate Documentation" workflow fails with:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution
Use a deploy key stored as `DOCS_DEPLOY_KEY` secret, which can bypass branch protection.

Deploy keys are preferable to PATs because:
- Scoped to single repository
- Not tied to a user account
- No expiration

## Required Setup
1. Generate key: `ssh-keygen -t ed25519 -C "docs-workflow" -f docs-deploy-key -N ""`
2. Add **public key** as deploy key with write access: Settings → Deploy keys
3. Add **private key** as secret `DOCS_DEPLOY_KEY`: Settings → Secrets

## Test plan
- [x] Workflow syntax valid
- [ ] Re-run docs workflow after merging and adding secret

🤖 Generated with [Claude Code](https://claude.ai/code)