### PR TITLE
fix(ci): use webfactory/ssh-agent for deploy key

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,9 +19,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-key: ${{ secrets.DOCS_DEPLOY_KEY }}
+          ssh-private-key: ${{ secrets.DOCS_DEPLOY_KEY }}
+
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Use dedicated ssh-agent action for more reliable SSH key loading.