### PR TITLE
fix(ci): use SSH remote URL for docs push

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,6 +57,7 @@ jobs:
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          git remote set-url origin git@github.com:${{ github.repository }}.git
           git add docs/
           git commit -m "docs: auto-regenerate documentation [skip ci]"
           git push


### PR DESCRIPTION
Checkout uses HTTPS by default. Switch to SSH URL so the deploy key gets used for pushing.