### PR TITLE
fix(ci): detect untracked wiki files

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Check for wiki changes
         id: wiki-changes
         run: |
-          if git diff --quiet docs/wiki/; then
+          # Check for both modified and untracked files
+          if [ -z "$(git status --porcelain docs/wiki/)" ]; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else
             echo "changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
git diff doesn't detect new untracked files. Use git status --porcelain instead.