### PR TITLE
chore: unignore docs/wiki for PR-based wiki sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ tarpaulin-report.html
 
 # Local agent settings (not to be committed)
 agents/settings.local.json
-docs/wiki/
 .wiki/
 .archive/
 wiki/

--- a/docs/wiki/Command-agents.md
+++ b/docs/wiki/Command-agents.md
@@ -1,0 +1,79 @@
+# agr agents
+
+Manage configured agents
+
+## Usage
+
+```
+agr agents [OPTIONS]
+```
+
+## Description
+
+Manage the list of AI agents that AGR knows about.
+
+Configured agents are used by shell integration to automatically
+record sessions. You can also control which agents are auto-wrapped
+using the no-wrap subcommand.
+
+EXAMPLES:
+    agr agents list                  Show configured agents
+    agr agents add claude            Add claude to the list
+    agr agents remove codex          Remove codex from the list
+    agr agents no-wrap add claude    Disable auto-wrap for claude
+
+## Subcommands
+
+### agents list
+
+List all configured agents
+
+List all agents configured for recording.
+
+These agents can be auto-recorded when shell integration is enabled.
+
+### agents add
+
+Add an agent to the configuration
+
+Add an agent to the configured list.
+
+Once added, the agent can be auto-recorded via shell integration.
+
+EXAMPLE:
+    agr agents add claude
+    agr agents add my-custom-agent
+
+### agents remove
+
+Remove an agent from the configuration
+
+Remove an agent from the configured list.
+
+The agent will no longer be auto-recorded via shell integration.
+
+EXAMPLE:
+    agr agents remove codex
+
+### agents is-wrapped
+
+Check if an agent should be wrapped (used by shell integration)
+
+Check if an agent should be auto-wrapped by shell integration.
+
+Returns exit code 0 if the agent should be wrapped, 1 if not.
+Used internally by the shell integration script.
+
+EXAMPLE:
+    agr agents is-wrapped claude && echo "Should wrap"
+
+### agents no-wrap
+
+Manage agents that should not be auto-wrapped
+
+Manage the no-wrap list for agents that should not be auto-recorded.
+
+Agents on this list will not be automatically wrapped by shell integration,
+even if they are in the configured agents list. Useful for temporarily
+disabling recording for specific agents.
+

--- a/docs/wiki/Command-analyze.md
+++ b/docs/wiki/Command-analyze.md
@@ -1,0 +1,42 @@
+# agr analyze
+
+Analyze a recording with AI
+
+## Usage
+
+```
+agr analyze [OPTIONS] <FILE>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `FILE` | Path to the .cast recording file |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-a, --agent` | Agent to use (overrides config) |
+
+## Description
+
+Analyze a recording file using an AI agent.
+
+The analyzer reads the cast file, identifies key moments (errors, decisions,
+milestones), and adds markers using 'agr marker add'. This is the same
+analysis that runs automatically when auto_analyze is enabled.
+
+The default agent is configured in ~/.config/agr/config.toml under
+[recording].analysis_agent. Use --agent to override for a single run.
+
+EXAMPLES:
+    agr analyze session.cast              Analyze with default agent
+    agr analyze session.cast --agent codex    Override agent for this run
+
+SUPPORTED AGENTS:
+    claude      Claude Code CLI
+    codex       OpenAI Codex CLI
+    gemini  Google Gemini CLI
+

--- a/docs/wiki/Command-cleanup.md
+++ b/docs/wiki/Command-cleanup.md
@@ -1,0 +1,37 @@
+# agr cleanup
+
+Interactive cleanup of old sessions
+
+## Usage
+
+```
+agr cleanup [OPTIONS]
+```
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--agent` | Only show sessions from this agent |
+| `--older-than` | Only show sessions older than N days |
+
+## Description
+
+Interactively delete old session recordings to free up disk space.
+
+Displays a list of sessions sorted by age and lets you choose how many
+to delete. Supports filtering by agent and age. Sessions older than
+the configured threshold (default: 30 days) are marked with *.
+
+EXAMPLES:
+    agr cleanup                          Interactive cleanup of all sessions
+    agr cleanup --agent claude           Only show Claude sessions
+    agr cleanup --older-than 60          Only show sessions older than 60 days
+    agr cleanup --agent codex --older-than 30
+
+INTERACTIVE OPTIONS:
+    [number]    Delete the N oldest sessions
+    'old'       Delete all sessions older than threshold
+    'all'       Delete all matching sessions
+    0           Cancel without deleting
+

--- a/docs/wiki/Command-config.md
+++ b/docs/wiki/Command-config.md
@@ -1,0 +1,48 @@
+# agr config
+
+Configuration management
+
+## Usage
+
+```
+agr config [OPTIONS]
+```
+
+## Description
+
+View and edit the AGR configuration file.
+
+Configuration is stored in ~/.config/agr/config.toml and includes
+storage settings, agent list, shell integration options, and more.
+
+EXAMPLES:
+    agr config show          Display current configuration
+    agr config edit          Open config in $EDITOR
+
+## Subcommands
+
+### config show
+
+Show current configuration as TOML
+
+Display the current configuration in TOML format.
+
+Shows all settings including storage paths, agent list, shell options,
+and recording preferences.
+
+EXAMPLE:
+    agr config show
+
+### config edit
+
+Open configuration file in your default editor
+
+Open the configuration file in your default editor.
+
+Uses the $EDITOR environment variable (defaults to 'vi').
+Config file location: ~/.config/agr/config.toml
+
+EXAMPLE:
+    agr config edit
+    EDITOR=nano agr config edit
+

--- a/docs/wiki/Command-list.md
+++ b/docs/wiki/Command-list.md
@@ -1,0 +1,29 @@
+# agr list
+
+List recorded sessions
+
+## Usage
+
+```
+agr list [OPTIONS] [AGENT]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `AGENT` | Filter sessions by agent name |
+
+## Description
+
+List all recorded sessions with details.
+
+Shows sessions sorted by date (newest first) with agent name,
+age, file size, and filename.
+
+EXAMPLES:
+    agr list                List all sessions
+    agr ls                  Same as 'agr list' (alias)
+    agr list claude         List only Claude sessions
+    agr list codex          List only Codex sessions
+

--- a/docs/wiki/Command-marker.md
+++ b/docs/wiki/Command-marker.md
@@ -1,0 +1,51 @@
+# agr marker
+
+Manage markers in cast files
+
+## Usage
+
+```
+agr marker [OPTIONS]
+```
+
+## Description
+
+Add and list markers in asciicast recording files.
+
+Markers are annotations at specific timestamps in a recording,
+useful for highlighting key moments like errors, decisions, or
+milestones. Markers use the native asciicast v3 marker format.
+
+EXAMPLES:
+    agr marker add session.cast 45.2 "Build failed"
+    agr marker add session.cast 120.5 "Deployment complete"
+    agr marker list session.cast
+
+## Subcommands
+
+### marker add
+
+Add a marker to a cast file at a specific timestamp
+
+Add a marker to a cast file at a specific timestamp.
+
+Markers are injected into the asciicast file using the native v3 marker
+format. The timestamp is cumulative seconds from the start of the recording.
+
+EXAMPLE:
+    agr marker add ~/recorded_agent_sessions/claude/session.cast 45.2 "Build error"
+
+### marker list
+
+List all markers in a cast file
+
+List all markers in a cast file with their timestamps and labels.
+
+EXAMPLE:
+    agr marker list ~/recorded_agent_sessions/claude/session.cast
+
+OUTPUT:
+    Markers:
+      [45.2s] Build error
+      [120.5s] Deployment complete
+

--- a/docs/wiki/Command-optimize.md
+++ b/docs/wiki/Command-optimize.md
@@ -1,0 +1,45 @@
+# agr optimize
+
+Optimize asciicast recordings (removes silence)
+
+## Usage
+
+```
+agr optimize [OPTIONS] <FILE>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `FILE` | Path to the .cast recording file |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--remove-silence` | Cap intervals at threshold (default: header or 2.0s) |
+| `-o, --output` | Output file path |
+
+## Description
+
+Optimize asciicast recording files by removing silence.
+
+Optimization modifies the timing of recordings by capping long pauses
+at a configurable threshold.
+
+THRESHOLD RESOLUTION:
+    1. CLI argument (explicit user intent)
+    2. Header's idle_time_limit (recording author's intent)
+    3. Default: 2.0 seconds
+
+EXAMPLES:
+    agr optimize --remove-silence session.cast
+        Use header's idle_time_limit or default 2.0s threshold
+
+    agr optimize --remove-silence=1.5 session.cast
+        Use explicit 1.5s threshold (note: requires = for value)
+
+    agr optimize --remove-silence --output fast.cast session.cast
+        Write to separate file, preserving original
+

--- a/docs/wiki/Command-play.md
+++ b/docs/wiki/Command-play.md
@@ -1,0 +1,37 @@
+# agr play
+
+Play a recording with the native player
+
+## Usage
+
+```
+agr play [OPTIONS] <FILE>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `FILE` | Path to the .cast recording file |
+
+## Description
+
+Play an asciicast recording using the native player.
+
+The native player supports seeking, speed control, and marker navigation.
+Recordings can be specified by absolute path, short format (agent/file.cast),
+or just filename (fuzzy matches across all agents).
+
+EXAMPLES:
+    agr play session.cast                 Play by filename (fuzzy match)
+    agr play claude/session.cast          Play using short format
+    agr play /path/to/session.cast        Play by absolute path
+
+PLAYER CONTROLS:
+    q, Esc      Quit
+    Space       Pause/resume
+    +/-         Adjust playback speed
+    <, > or ,, .  Seek backward/forward 5s
+    m           Jump to next marker
+    ?           Show help overlay
+

--- a/docs/wiki/Command-record.md
+++ b/docs/wiki/Command-record.md
@@ -1,0 +1,38 @@
+# agr record
+
+Start recording a session
+
+## Usage
+
+```
+agr record [OPTIONS] <AGENT> [ARGS]
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `AGENT` | Agent name (e.g., claude, codex, gemini) |
+| `ARGS` | Arguments to pass to the agent (after --) |
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `-n, --name` | Session name (skips rename prompt) |
+
+## Description
+
+Start recording an AI agent session with asciinema.
+
+The recording is saved to ~/recorded_agent_sessions/<agent>/<timestamp>.cast
+in asciicast v3 format. When the session ends, you can optionally rename
+the recording for easier identification.
+
+EXAMPLES:
+    agr record claude                    Record a Claude Code session
+    agr record codex                     Record an OpenAI Codex session
+    agr record claude --name my-session  Record with a specific filename
+    agr record claude -- --help          Pass --help flag to claude
+    agr record gemini -- chat        Start gemini in chat mode
+

--- a/docs/wiki/Command-shell.md
+++ b/docs/wiki/Command-shell.md
@@ -1,0 +1,67 @@
+# agr shell
+
+Manage shell integration
+
+## Usage
+
+```
+agr shell [OPTIONS]
+```
+
+## Description
+
+Manage automatic session recording via shell integration.
+
+Shell integration adds wrapper functions to your shell that automatically
+record sessions when you run configured agents. It modifies your .zshrc
+or .bashrc with a clearly marked section.
+
+EXAMPLES:
+    agr shell status         Check if shell integration is installed
+    agr shell install        Install shell integration
+    agr shell uninstall      Remove shell integration
+
+After installing, restart your shell or run: source ~/.zshrc
+
+## Subcommands
+
+### shell status
+
+Show shell integration status
+
+Show the current status of shell integration.
+
+Displays whether shell integration is installed, which RC file
+is configured, and whether auto-wrap is enabled.
+
+EXAMPLE:
+    agr shell status
+
+### shell install
+
+Install shell integration to .zshrc/.bashrc
+
+Install shell integration for automatic session recording.
+
+Adds a clearly marked section to your .zshrc (or .bashrc) that
+sources the AGR shell script. This creates wrapper functions for
+configured agents that automatically record sessions.
+
+After installation, restart your shell or run:
+    source ~/.zshrc
+
+EXAMPLE:
+    agr shell install
+
+### shell uninstall
+
+Remove shell integration from .zshrc/.bashrc
+
+Remove shell integration from your shell configuration.
+
+Removes the AGR section from your .zshrc/.bashrc and deletes
+the shell script. Restart your shell after uninstalling.
+
+EXAMPLE:
+    agr shell uninstall
+

--- a/docs/wiki/Command-status.md
+++ b/docs/wiki/Command-status.md
@@ -1,0 +1,25 @@
+# agr status
+
+Show storage statistics
+
+## Usage
+
+```
+agr status [OPTIONS]
+```
+
+## Description
+
+Display storage statistics for recorded sessions.
+
+Shows total size, disk usage percentage, session count by agent,
+and age of the oldest recording.
+
+EXAMPLE:
+    agr status
+
+OUTPUT:
+    Agent Sessions: 1.2 GB (0.5% of disk)
+       Sessions: 23 total (claude: 15, codex: 8)
+       Oldest: 2025-01-01 (20 days ago)
+

--- a/docs/wiki/Command-usage.md
+++ b/docs/wiki/Command-usage.md
@@ -1,0 +1,25 @@
+# agr usage
+
+Show storage statistics
+
+## Usage
+
+```
+agr usage [OPTIONS]
+```
+
+## Description
+
+Display storage statistics for recorded sessions.
+
+Shows total size, disk usage percentage, session count by agent,
+and age of the oldest recording.
+
+EXAMPLE:
+    agr usage
+
+OUTPUT:
+    Agent Sessions: 1.2 GB (0.5% of disk)
+       Sessions: 23 total (claude: 15, codex: 8)
+       Oldest: 2025-01-01 (20 days ago)
+

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,17 @@
+# AGR Wiki
+
+Welcome to the AGR (Agent Session Recorder) wiki.
+
+## Commands
+
+- [[record|Command-record]] - Start recording a session
+- [[status|Command-status]] - Show storage statistics
+- [[cleanup|Command-cleanup]] - Interactive cleanup of old sessions
+- [[list|Command-list]] - List recorded sessions
+- [[analyze|Command-analyze]] - Analyze a recording with AI
+- [[play|Command-play]] - Play a recording with the native player
+- [[marker|Command-marker]] - Manage markers in cast files
+- [[agents|Command-agents]] - Manage configured agents
+- [[config|Command-config]] - Configuration management
+- [[shell|Command-shell]] - Manage shell integration
+- [[optimize|Command-optimize]] - Optimize asciicast recordings (removes silence)


### PR DESCRIPTION
Remove docs/wiki/ from .gitignore so the docs workflow can create PRs for wiki changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced comprehensive wiki documentation for all AGR commands including record, status, cleanup, list, analyze, play, marker, agents, config, shell, optimize, and usage, with detailed usage syntax, options, descriptions, and practical examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->