### PR TITLE
docs: fix incorrect Linux clipboard behavior in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ agr copy ~/recorded_agent_sessions/claude/session.cast
 ```
 
 **Platform Behavior:**
-- **macOS**: Copies the file as a file reference - paste directly into Slack, email, etc. as an attachment
-- **Linux**: Copies the file content as text (file reference copy not widely supported)
+- **macOS**: Copies as file reference (POSIX file) - paste directly into Slack, email, etc. as an attachment
+- **Linux**: Copies as file URI (`text/uri-list`) - works in modern DEs (GNOME, KDE) for file paste
 
 ## Interactive File Browser
 


### PR DESCRIPTION
Linux actually copies as file URI (text/uri-list), not text content.