### PR TITLE
fix: use integer ilog10 instead of floating-point log10

### DIFF
--- a/src/player/render/status.rs
+++ b/src/player/render/status.rs
@@ -18,7 +18,7 @@ pub fn count_digits(n: usize) -> usize {
     if n == 0 {
         1
     } else {
-        (n as f64).log10().floor() as usize + 1
+        n.ilog10() as usize + 1
     }
 }
 


### PR DESCRIPTION
## Summary
- Fixes floating-point precision bug in `count_digits()` function
- Detected by Miri's strict floating-point execution model
- `log10(10.0)` can return `0.999999...` causing `floor()` to give wrong results
- Uses `ilog10` (stable since Rust 1.67) for exact integer results

## Test plan
- [x] All `count_digits` tests pass
- [x] Verified fix under Miri

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal calculation logic for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->