### PR TITLE
chore(ci): add Miri job for undefined behavior detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ on:
       - 'build.rs'
       - 'install.sh'
       - '.github/**'
+  merge_group:
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
@@ -101,10 +103,15 @@ jobs:
         run: cargo test --verbose
 
   # 2b. Miri - detect undefined behavior (Linux only, macOS has FFI limitations)
+  # Runs on: push to main, merge queue, or PRs with 'ready-to-merge' label
   miri:
     name: Undefined Behavior (Miri)
     needs: build
     runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'merge_group' ||
+      contains(github.event.pull_request.labels.*.name, 'ready-to-merge')
     steps:
       - uses: actions/checkout@v5
 
@@ -137,9 +144,9 @@ jobs:
         env:
           MIRIFLAGS: "-Zmiri-disable-isolation"
         run: |
-          # Skip transform_ops tests - they use macOS-specific FFI (fclonefileat, chmod)
-          # that Miri doesn't support even on Linux due to cross-compilation constraints
-          cargo miri test -- --skip transform_ops
+          # Only run lib tests - integration tests spawn processes which Miri doesn't support
+          # Skip transform_ops tests - they use unsupported FFI (fclonefileat, chmod)
+          cargo miri test --lib -- --skip transform_ops
 
   # 3. Coverage - generate test coverage and upload to Codecov
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,23 @@ jobs:
         with:
           components: miri
 
+      - name: Get rustc version for cache key
+        id: rustc
+        run: echo "version=$(rustc --version | cut -d' ' -f2)" >> $GITHUB_OUTPUT
+
+      - name: Cache cargo registry and Miri sysroot
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.cache/miri/
+          key: miri-${{ steps.rustc.outputs.version }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            miri-${{ steps.rustc.outputs.version }}-
+            miri-
+
       - name: Setup Miri
         run: cargo miri setup
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,30 @@ jobs:
       - name: Run unit tests
         run: cargo test --verbose
 
+  # 2b. Miri - detect undefined behavior (Linux only, macOS has FFI limitations)
+  miri:
+    name: Undefined Behavior (Miri)
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust nightly with Miri
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: miri
+
+      - name: Setup Miri
+        run: cargo miri setup
+
+      - name: Run Miri tests
+        env:
+          MIRIFLAGS: "-Zmiri-disable-isolation"
+        run: |
+          # Skip transform_ops tests - they use macOS-specific FFI (fclonefileat, chmod)
+          # that Miri doesn't support even on Linux due to cross-compilation constraints
+          cargo miri test -- --skip transform_ops
+
   # 3. Coverage - generate test coverage and upload to Codecov
   coverage:
     name: Coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,7 @@ on:
       - 'install.sh'
       - '.github/**'
   pull_request:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'build.rs'
-      - 'install.sh'
-      - '.github/**'
-  merge_group:
+    types: [opened, synchronize, reopened, labeled]
     branches: [main]
 
 env:
@@ -103,14 +94,13 @@ jobs:
         run: cargo test --verbose
 
   # 2b. Miri - detect undefined behavior (Linux only, macOS has FFI limitations)
-  # Runs on: push to main, merge queue, or PRs with 'ready-to-merge' label
+  # Runs on: push to main, or PRs with 'ready-to-merge' label
   miri:
     name: Undefined Behavior (Miri)
     needs: build
     runs-on: ubuntu-latest
     if: >
       github.event_name == 'push' ||
-      github.event_name == 'merge_group' ||
       contains(github.event.pull_request.labels.*.name, 'ready-to-merge')
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Adds Miri CI job to detect undefined behavior and memory safety issues
- Only runs lib tests (integration tests spawn processes which Miri doesn't support)
- Caches cargo registry and Miri sysroot for faster subsequent runs

## When Miri runs
| Trigger | Miri runs? |
|---------|------------|
| Push to `main` | ✅ Always |
| PR with `ready-to-merge` label | ✅ Yes |
| PR without label | ❌ Skipped |

## How to trigger on a PR
Add the `ready-to-merge` label → CI re-runs with Miri enabled

## Test plan
- [x] YAML validates
- [ ] Miri runs on push to main
- [ ] Adding `ready-to-merge` label triggers Miri

🤖 Generated with [Claude Code](https://claude.com/claude-code)