### PR TITLE
fix(docs): correct gitignore pattern and add missing Command-copy.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,4 @@ tarpaulin-report.html
 agents/settings.local.json
 .wiki/
 .archive/
-wiki/
+/wiki/

--- a/docs/wiki/Command-copy.md
+++ b/docs/wiki/Command-copy.md
@@ -1,0 +1,32 @@
+# agr copy
+
+Copy a recording to the clipboard
+
+## Usage
+
+```
+agr copy [OPTIONS] <FILE>
+```
+
+## Arguments
+
+| Argument | Description |
+|----------|-------------|
+| `FILE` | Path to the .cast recording file |
+
+## Description
+
+Copy a recording file to the system clipboard.
+
+On macOS, the file is copied as a file reference, allowing direct paste
+into Slack, email, or other applications as an attachment. On Linux,
+the file content is copied as text (file copy not supported).
+
+Recordings can be specified by absolute path, short format (agent/file.cast),
+or just filename (fuzzy matches across all agents).
+
+EXAMPLES:
+    agr copy session.cast                 Copy by filename (fuzzy match)
+    agr copy claude/session.cast          Copy using short format
+    agr copy /path/to/session.cast        Copy by absolute path
+


### PR DESCRIPTION
## Summary
- Fix `.gitignore` pattern `wiki/` → `/wiki/` to only match root-level wiki directory
- The old pattern was matching `docs/wiki/` which prevented new wiki pages from being tracked
- Add `Command-copy.md` which was untracked due to this bug

## Root Cause
```
.gitignore:32:wiki/    docs/wiki/Command-copy.md
```
The pattern `wiki/` matches any path containing `wiki/`, including `docs/wiki/`.

## Files Modified
- `.gitignore` - fix pattern
- `docs/wiki/Command-copy.md` - add missing wiki page

## Test plan
- [x] `git check-ignore docs/wiki/Command-copy.md` returns nothing (not ignored)
- [x] Wiki sync workflow should now pick up new command pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the `agr copy` command, including usage examples, argument specifications, and platform-specific behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->