### PR TITLE
fix(player): use current buffer dimensions for viewport calculations

### DIFF
--- a/src/player/input/mod.rs
+++ b/src/player/input/mod.rs
@@ -62,7 +62,7 @@ pub fn handle_event(
             rec_rows,
         ),
         Event::Resize(new_cols, new_rows) => {
-            state.handle_resize(new_cols, new_rows, rec_cols, rec_rows);
+            state.handle_resize(new_cols, new_rows, buffer.width(), buffer.height());
             InputResult::Continue
         }
         _ => InputResult::Continue, // Ignore focus events, etc.

--- a/src/player/native.rs
+++ b/src/player/native.rs
@@ -256,8 +256,8 @@ fn run_main_loop(
                     state.view_col_offset(),
                     state.view_rows,
                     state.view_cols,
-                    rec_rows as usize,
-                    rec_cols as usize,
+                    buffer.height(),
+                    buffer.width(),
                 )?;
 
                 render_separator_line(stdout, state.term_cols, state.term_rows.saturating_sub(3))?;
@@ -277,8 +277,8 @@ fn run_main_loop(
                     state.term_rows.saturating_sub(1),
                     state.paused,
                     state.speed,
-                    rec_cols,
-                    rec_rows,
+                    buffer.width() as u32,
+                    buffer.height() as u32,
                     state.view_cols,
                     state.view_rows,
                     state.view_col_offset(),

--- a/src/player/state.rs
+++ b/src/player/state.rs
@@ -150,17 +150,23 @@ impl PlaybackState {
     /// # Arguments
     /// * `new_cols` - New terminal width
     /// * `new_rows` - New terminal height
-    /// * `rec_cols` - Recording width (for clamping)
-    /// * `rec_rows` - Recording height (for clamping)
-    pub fn handle_resize(&mut self, new_cols: u16, new_rows: u16, rec_cols: u32, rec_rows: u32) {
+    /// * `buf_cols` - Current buffer width (for clamping)
+    /// * `buf_rows` - Current buffer height (for clamping)
+    pub fn handle_resize(
+        &mut self,
+        new_cols: u16,
+        new_rows: u16,
+        buf_cols: usize,
+        buf_rows: usize,
+    ) {
         self.term_cols = new_cols;
         self.term_rows = new_rows;
         self.view_rows = (new_rows.saturating_sub(Self::STATUS_LINES)) as usize;
         self.view_cols = new_cols as usize;
 
         // Clamp viewport offset to valid range
-        let max_row_offset = (rec_rows as usize).saturating_sub(self.view_rows);
-        let max_col_offset = (rec_cols as usize).saturating_sub(self.view_cols);
+        let max_row_offset = buf_rows.saturating_sub(self.view_rows);
+        let max_col_offset = buf_cols.saturating_sub(self.view_cols);
         self.view_row_offset = self.view_row_offset.min(max_row_offset);
         self.view_col_offset = self.view_col_offset.min(max_col_offset);
 


### PR DESCRIPTION
## Summary
- Player used static `rec_cols`/`rec_rows` from cast header for viewport calculations, but `buffer.resize()` changes actual dimensions during playback via resize events
- Replaced static header dimensions with `buffer.width()`/`buffer.height()` in viewport clamping, scroll indicators, resize handler, and arrow key bounds
- Original header dimensions preserved only for seeking (where fresh buffers are created at initial size)

## Test plan
- [x] `cargo test` — all 740 tests pass
- [x] `cargo clippy` — no warnings
- [x] Manual: play recording with resize events, press `r`, verify terminal resizes to current buffer dimensions
- [x] Manual: shrink window smaller than recording with resize events, verify content accessible via viewport scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Viewport navigation and resizing now use the live terminal buffer size, fixing incorrect scrolling boundaries when the terminal differs from the original recording.
  * Scroll indicator and status bar rendering now reflect actual buffer dimensions.
  * Offset clamping and viewport bounds were corrected and view updates now reliably trigger after resize.
  * Tests expanded to cover wider/taller buffer scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->