### PR TITLE
feat(tui): add rename action to ls file explorer

### DIFF
--- a/.state/INDEX.md
+++ b/.state/INDEX.md
@@ -33,6 +33,7 @@ git log --oneline -5
 **Current focus:** None (phase complete)
 
 **Recently completed:**
+- Add rename action to ls file explorer: inline rename in TUI, event bus Esc/q fix, input mode highlighting, rename validation with reserved names (PR #127)
 - Fix recording rename race condition: lock file protocol, inode/header recovery, ProcessGuard, live file discovery, lock-aware TUI, signal_hook SIGINT handling (PR #126)
 - Modularize TUI apps into shared framework: TuiApp trait, SharedState, unified keybindings, thread pool preview cache, generic AsyncLruCache (PR #125)
 - Refactor analyze command: parallel LLM analysis with content extraction pipeline, multi-backend support, and aggressive noise reduction (PR #112)
@@ -52,6 +53,7 @@ Historical context for all state directories:
 
 | Directory | Description |
 |-----------|-------------|
+| feature-ls-rename-action | Inline rename in TUI, event bus Esc/q fix, input mode highlighting, rename validation with reserved names |
 | fix-recording-rename-race-condition | Lock file protocol, inode/header recovery, ProcessGuard, live file discovery, lock-aware TUI, signal_hook SIGINT |
 | refactor-tui-apps | TuiApp trait framework, SharedState, unified keybindings, thread pool preview cache, generic AsyncLruCache |
 | refactor-analyze-command | Parallel LLM analysis with content extraction, multi-backend support, noise reduction |

--- a/.state/feature-ls-rename-action/ADR.md
+++ b/.state/feature-ls-rename-action/ADR.md
@@ -1,7 +1,7 @@
 # ADR: Add Rename Action to `agr ls` TUI
 
 ## Status
-Proposed
+Accepted
 
 ## Context
 

--- a/.state/feature-ls-rename-action/ADR.md
+++ b/.state/feature-ls-rename-action/ADR.md
@@ -1,0 +1,150 @@
+# ADR: Add Rename Action to `agr ls` TUI
+
+## Status
+Proposed
+
+## Context
+
+The `agr ls` TUI provides an interactive file explorer for managing session recordings. Currently it supports Play, Copy, Optimize, Analyze, Restore, Delete, and Add Marker actions. Two usability improvements are needed:
+
+1. **Rename support**: Users cannot rename recordings from within the TUI. They must exit, manually rename the `.cast` file on disk, and re-enter. This is friction-heavy, especially after AI analysis which often renames files automatically.
+
+2. **Menu cleanup**: The AddMarker action is a placeholder ("coming soon!") that occupies a shortcut key (`m`) and menu slot. The Optimize hint line adds vertical noise. The context menu ordering does not follow a clear intent-based grouping.
+
+### Technical Context
+
+The codebase already has:
+- `FileExplorer::update_item_path(old_path, new_path)` for in-place path/name updates after rename
+- `Mode::Search` with inline text input (Backspace/Enter/Esc) as a pattern for text input modes
+- `Mode::ConfirmDelete` and `Mode::ConfirmUnlock` as patterns for modal confirmation flows
+- `preview_cache.invalidate()` for cache cleanup after file changes
+- `backup_path_for()` which appends `.bak` to the original path (e.g., `session.cast.bak`)
+- `ContextMenuItem` enum with `ALL` const array and `label()`/`shortcut()` methods
+
+### Requirements Summary
+
+1. Add `Rename` action with `r` shortcut key (Normal mode + context menu)
+2. Remove `AddMarker` action entirely (enum variant, menu, shortcut, method)
+3. Remove silence hint line from context menu Optimize entry
+4. Reorder context menu by intent grouping
+5. Interactive inline text input for entering new filename
+
+## Options Considered
+
+### Option A: Inline Status Bar Input (like Search mode)
+
+Add `Mode::RenameInput` that renders a text input in the status bar area, following the same pattern as `Mode::Search`.
+
+**How it works:**
+- User presses `r` in Normal mode (or selects Rename in context menu)
+- Status bar shows: `Rename: current_stem_` with a cursor
+- `rename_input: String` field on `ListApp` pre-filled with current filename stem
+- Typing replaces characters, Backspace deletes, Enter confirms, Esc cancels
+- On Enter: validate, rename filesystem files, update explorer, invalidate cache
+
+**Pros:**
+- Follows the established Search mode pattern exactly (same key handling structure)
+- Minimal new rendering code; reuses status bar area
+- Lightweight and fast; no modal overlay to render/clear
+- Users already understand this interaction from Search mode
+
+**Cons:**
+- Status bar is a single line; long filenames may truncate
+- Less visually prominent; user might not notice the mode change
+- No room for error messages inline (must use status message after)
+
+### Option B: Centered Modal Dialog (like ConfirmDelete)
+
+Add `Mode::RenameInput` that renders a centered modal dialog with a text input field.
+
+**How it works:**
+- User presses `r`, a centered modal appears with:
+  - Title: "Rename Session"
+  - Current name display
+  - Text input field with cursor
+  - Footer: "Enter: confirm | Esc: cancel"
+- Same keyboard handling as Option A, but rendered in a modal
+
+**Pros:**
+- More visually prominent; impossible to miss
+- Room for current name, input field, and inline error messages
+- Consistent with other modal interactions (ConfirmDelete, OptimizeResult)
+
+**Cons:**
+- More rendering code (new modal layout, Clear behind it, border styling)
+- Overkill for a simple text input; modals in this TUI are for confirmations
+- Modals in the codebase are read-only or y/n; a text-input modal would be a new pattern
+
+## Decision
+
+**Option A: Inline Status Bar Input**
+
+Rationale:
+1. **Pattern consistency**: The TUI already has a well-tested inline text input mode (Search). Rename is structurally identical -- type text, Enter to confirm, Esc to cancel. Reusing this pattern minimizes new code and cognitive load.
+2. **Modal purpose mismatch**: Existing modals (ConfirmDelete, ConfirmUnlock, OptimizeResult) display information and accept y/n or Enter/Esc. They do not accept freeform text. Introducing a text-input modal would be a new pattern that doesn't match existing usage.
+3. **Simplicity**: The status bar line is sufficient for filename stems (which are typically short). Error feedback goes to the status message after the operation, consistent with how Copy, Optimize, and Delete report results.
+
+### Rename Behavior Specification
+
+- **Input**: Pre-filled with the current filename stem (without `.cast` extension), **entire stem selected** (first keystroke replaces all — natural for replacing)
+- **Input validation (real-time, as user types)**:
+  - Reject characters in `INVALID_CHARS` from `src/files/filename.rs`: `['/', '\\', ':', '*', '?', '"', '<', '>', '|']`
+  - Enforce 255 char max length via `filename::validate_length()` — silently refuse chars beyond limit
+- **Validation on Enter**:
+  - Empty input: reject, show error status message
+  - Same as current name: no-op, return to Normal mode
+  - Target file already exists: reject with "File already exists" message
+- **Filesystem operations**: Generalized `rename_file(old_path, new_stem)` in `src/files/filename.rs`, reusing `INVALID_CHARS`, `validate_length()`, and `backup::backup_path_for()`. Extension-agnostic — preserves original extension, works for any file type.
+  1. Rename `old_stem.{ext}` to `new_stem.{ext}` (same directory, same extension)
+  2. If backup exists (via `backup_path_for()`), rename backup too (best-effort)
+  3. Return new path for the caller (TUI) to handle cache/explorer updates
+- **TUI integration** (`list_app.rs`): After successful rename, invalidate preview cache + update explorer via `update_item_path()`
+- **Lock check**: If file is locked, show ConfirmUnlock first (same as other actions)
+
+### Context Menu Reorder
+
+New order grouped by intent:
+
+| # | Item | Shortcut | Intent |
+|---|------|----------|--------|
+| 1 | Play | p | View |
+| 2 | Copy | c | Export |
+| 3 | Rename | r | Modify (name) |
+| 4 | Optimize | t | Modify (content) |
+| 5 | Analyze | a | Modify (content) |
+| 6 | Restore | -- | Revert |
+| 7 | Delete | d | Destructive |
+
+Restore loses its `r` shortcut (now used by Rename) and becomes menu-only. This is acceptable because Restore is an infrequent recovery action.
+
+## Consequences
+
+### What becomes easier
+- Renaming recordings from within the TUI (no need to exit)
+- Context menu is cleaner (no placeholder AddMarker, no silence hint noise)
+- Menu ordering follows predictable intent grouping (view, export, modify, revert, destroy)
+
+### What becomes harder
+- Restore is no longer accessible via a direct shortcut key from Normal mode
+- Users accustomed to `m` for marker must unlearn the muscle memory (but the feature was a placeholder anyway)
+
+### Technical debt considerations
+- `rename_input` field and `rename_selected_all` flag added to `ListApp` struct (small increase in state)
+- Rename function added to existing `src/files/filename.rs` (reuses `INVALID_CHARS`, `validate_length()`, `backup_path_for()`)
+- Seven snapshot tests need regeneration (context menu + help modal)
+- Two unit tests updated (`context_menu_has_seven_items` stays at 7, `context_menu_item_order` changes)
+
+### Risks
+- Race condition: another process could create the target file between existence check and rename. On Unix, `fs::rename()` silently **overwrites** the target (POSIX semantics), so the check-then-act is inherently racy. Acceptable for a single-user TUI tool — not a multi-tenant file server. Noted for honesty; no mitigation needed.
+
+## Decision History
+
+1. User decided: `r` shortcut moves from Restore to Rename
+2. User decided: Remove Add marker entirely
+3. User decided: Remove silence hint from context menu
+4. User decided: Reorder context menu by intent grouping
+5. Architect decided: Inline status bar input (Option A) over modal dialog (Option B)
+6. User decided: Select entire stem on pre-fill (first keystroke replaces all)
+7. User decided: Reject invalid chars as typed (using `INVALID_CHARS` from `filename.rs`)
+8. User decided: Enforce 255 char limit during typing (not just on submit)
+9. User decided: Rename function goes in existing `src/files/filename.rs` — no new module, reuses INVALID_CHARS/validate_length already there

--- a/.state/feature-ls-rename-action/PLAN.md
+++ b/.state/feature-ls-rename-action/PLAN.md
@@ -1,0 +1,290 @@
+# Plan: Add Rename Action to `agr ls` TUI
+
+References: ADR.md
+
+## Open Questions
+
+All resolved:
+
+1. ~~Cursor position on pre-fill~~ → **Select entire stem** (first keystroke replaces all)
+2. ~~Invalid characters~~ → **Reject invalid chars as typed** using `INVALID_CHARS` from `filename.rs`
+3. ~~Maximum name length~~ → **Enforce 255 char limit during typing** via `filename::MAX_FILENAME_LENGTH`
+
+---
+
+## Stages
+
+### Stage 1: Remove AddMarker and Clean Up Context Menu
+
+**Goal**: Remove the placeholder AddMarker action, remove the silence hint line, and reorder the context menu. This is a standalone cleanup that reduces the menu from 7 items (with AddMarker) to 6 items (before Rename is added in Stage 3).
+
+#### Changes
+
+**`src/tui/list_app.rs` -- ContextMenuItem enum:**
+- [ ] Remove `ContextMenuItem::AddMarker` variant
+- [ ] Update `ContextMenuItem::ALL` array: remove AddMarker, reorder to [Play, Copy, Optimize, Analyze, Restore, Delete] (6 items)
+- [ ] Remove `AddMarker` arms from `label()` and `shortcut()` matches
+- [ ] Remove `Restore` shortcut: change `shortcut()` to return `""` for Restore
+- [ ] Add `has_shortcut()` method: returns `!self.shortcut().is_empty()` — used by rendering
+
+**`src/tui/list_app.rs` -- Key handlers:**
+- [ ] Remove `KeyCode::Char('m')` arm from `handle_normal_key()`
+- [ ] Remove `KeyCode::Char('m')` arm from `handle_context_menu_key()`
+- [ ] Remove `KeyCode::Char('r')` arm from `handle_context_menu_key()` (Restore shortcut removed; will be re-added for Rename in Stage 3)
+
+**`src/tui/list_app.rs` -- `execute_context_menu_action()`:**
+- [ ] Remove `ContextMenuItem::AddMarker => self.add_marker()?` arm
+
+**`src/tui/list_app.rs` -- `add_marker()` method:**
+- [ ] Delete the `add_marker()` method entirely
+
+**`src/tui/list_app.rs` -- `render_context_menu_modal()`:**
+- [ ] Remove the silence hint block (the `if matches!(item, ContextMenuItem::Optimize)` that adds "Removes silence from recording")
+- [ ] Update `modal_height` calculation (remove the `+ optimize hint` allowance)
+- [ ] Fix shortcut rendering: use conditional format — show `"  {} ({})"` only when `has_shortcut()`, otherwise `"  {}"` (no empty parens for Restore)
+
+**`src/tui/list_app.rs` -- `render_help_modal()`:**
+- [ ] No changes in this stage (help modal does not mention `m` or `r` for Restore; it stays as-is)
+
+**`src/tui/list_app.rs` -- Footer:**
+- [ ] No changes in this stage (footer does not mention `m` or `r`)
+
+**`src/tui/list_app.rs` -- Tests:**
+- [ ] Update `context_menu_has_seven_items` test: rename to `context_menu_has_six_items`, assert `ALL.len() == 6`
+- [ ] Update `context_menu_item_order` test: assert new order [Play, Copy, Optimize, Analyze, Restore, Delete]
+- [ ] Remove or update `context_menu_copy_label_and_shortcut` if it references AddMarker
+- [ ] Fix `context_menu_items_have_shortcuts` test: change assertion to allow empty shortcut for menu-only items (Restore), e.g. check `has_shortcut()` returns `true` for items with shortcuts and `false` for Restore
+
+**Snapshot tests to regenerate:**
+- [ ] `context_menu_first_item.snap`
+- [ ] `context_menu_last_item.snap`
+- [ ] `context_menu_delete_selected.snap`
+- [ ] `context_menu_restore_no_backup.snap`
+- [ ] `context_menu_restore_with_backup.snap`
+- [ ] `context_menu_transform_selected.snap`
+
+**Verify:** `cargo test tui::list_app && cargo test --test snapshot_tui_test`
+
+---
+
+### Stage 2: Add Input Validation Helpers + Mode::RenameInput + Key Handling
+
+**Goal**: Expose validation helpers from `filename.rs` that the TUI needs, then add `Mode::RenameInput`, key handling, and context menu integration. No filesystem rename logic yet.
+
+#### Changes
+
+**`src/files/filename.rs` -- Public helpers (needed by TUI for real-time input validation):**
+- [ ] Make `INVALID_CHARS` public: `pub const INVALID_CHARS`
+- [ ] Make `MAX_FILENAME_LENGTH` public: `pub const MAX_FILENAME_LENGTH`
+- [ ] Add `pub fn is_valid_filename_char(c: char) -> bool` — returns `!INVALID_CHARS.contains(&c)`
+- [ ] Remove `#[allow(dead_code)]` from `validate_length()` (now used)
+
+**`src/tui/list_app.rs` -- Mode enum:**
+- [ ] Add `RenameInput` variant to `Mode` enum
+- [ ] Add arm to `Mode::to_shared()`: `Mode::RenameInput => None` (app-specific, not shared)
+
+**`src/tui/list_app.rs` -- ListApp struct:**
+- [ ] Add `rename_input: String` field
+- [ ] Add `rename_selected_all: bool` field (tracks if entire stem is still "selected")
+- [ ] Initialize as `String::new()` and `false` in `ListApp::new()`
+
+**`src/tui/list_app.rs` -- `handle_normal_key()`:**
+- [ ] Add `KeyCode::Char('r')` arm:
+  - Check `is_selected_locked()` -> `Mode::ConfirmUnlock`
+  - Check `selected_item().is_some()`
+  - Pre-fill `rename_input` with current filename stem (strip `.cast` extension)
+  - Set `rename_selected_all = true`
+  - Set `mode = Mode::RenameInput`
+
+**`src/tui/list_app.rs` -- New `handle_rename_input_key()` method:**
+- [ ] `KeyCode::Esc` -> set `mode = Mode::Normal`
+- [ ] `KeyCode::Enter` -> call `self.rename_session()` (implemented in Stage 3), set `mode = Mode::Normal`
+- [ ] `KeyCode::Backspace`:
+  - If `rename_selected_all` -> clear entire `rename_input`, set `rename_selected_all = false`
+  - Else -> pop last char from `rename_input`
+- [ ] `KeyCode::Char(c)`:
+  - Reject if `!filename::is_valid_filename_char(c)` (uses `INVALID_CHARS`)
+  - Reject if total length would exceed `MAX_FILENAME_LENGTH - ext_len` (compute dynamically from selected item's extension, e.g. `.cast` = 5)
+  - If `rename_selected_all` -> replace entire `rename_input` with `c`, set `rename_selected_all = false`
+  - Else -> push `c` to `rename_input`
+- [ ] All other keys -> no-op (consumed)
+
+**`src/tui/list_app.rs` -- `handle_key()` (TuiApp impl):**
+- [ ] Add `Mode::RenameInput => self.handle_rename_input_key(key)?` arm in app-specific match
+
+**`src/tui/list_app.rs` -- `draw()` (TuiApp impl):**
+- [ ] Add `Mode::RenameInput` arm in status_text match:
+  - If `rename_selected_all`: show `"Rename: [current_stem]"` (brackets indicate selection)
+  - Else: show `"Rename: {rename_input}_"` (underscore cursor at end)
+- [ ] Add `Mode::RenameInput` arm in footer_text match: `"Enter: confirm | Esc: cancel | Backspace: delete char"`
+
+**`src/tui/list_app.rs` -- Context menu integration:**
+- [ ] Add `ContextMenuItem::Rename` variant to enum
+- [ ] Update `ContextMenuItem::ALL` array: insert Rename at position 2 (after Copy), making it 7 items: [Play, Copy, Rename, Optimize, Analyze, Restore, Delete]
+- [ ] Add `label()` arm: `"Rename"`
+- [ ] Add `shortcut()` arm: `"r"`
+- [ ] Add `KeyCode::Char('r')` arm to `handle_context_menu_key()` (points to Rename)
+- [ ] Add `ContextMenuItem::Rename` arm to `execute_context_menu_action()`: pre-fill input, set `mode = Mode::RenameInput`
+
+**`src/tui/list_app.rs` -- Help modal:**
+- [ ] Add `r` / `Rename` line in Actions section (after Copy, before Optimize)
+- [ ] Update `modal_height` if needed
+
+**`src/tui/list_app.rs` -- Footer:**
+- [ ] Add `r: rename` to Normal mode footer text
+
+**Tests:**
+- [ ] `mode_equality` covers RenameInput
+- [ ] `context_menu_has_six_items` -> rename to `context_menu_has_seven_items`, assert `ALL.len() == 7`
+- [ ] `context_menu_item_order` updated for new 7-item order
+- [ ] New test: `rename_mode_esc_returns_to_normal`
+- [ ] New test: `rename_mode_backspace_removes_char`
+- [ ] New test: `rename_mode_char_appends`
+- [ ] New test: `rename_mode_rejects_invalid_chars` (uses `INVALID_CHARS`)
+- [ ] New test: `rename_mode_enforces_length_limit`
+- [ ] New test: `rename_selected_all_first_char_replaces`
+- [ ] New test: `rename_selected_all_backspace_clears`
+- [ ] New test: `rename_prefills_current_stem`
+
+**Verify:** `cargo test tui::list_app && cargo test --test snapshot_tui_test`
+
+---
+
+### Stage 3: Implement Rename Filesystem Logic
+
+**Goal**: Add a generalized `rename_file()` function to `src/files/filename.rs` that handles validation and filesystem rename. Then wire it into `list_app.rs` via a thin `rename_session()` method. Fix `update_item_path()` to re-sort/re-filter.
+
+#### Changes
+
+**`src/files/filename.rs` -- New `rename_file()` public function:**
+- [ ] Signature: `pub fn rename_file(old_path: &Path, new_stem: &str) -> Result<PathBuf, RenameError>`
+- [ ] Generalized — preserves original extension, works for any file type
+- [ ] Validate `new_stem`:
+  - Empty -> `RenameError::EmptyName`
+  - Same as current stem -> return `Ok(old_path.to_path_buf())` (no-op)
+  - Contains any char from `INVALID_CHARS` -> `RenameError::InvalidChars`
+  - Is a Windows reserved name (reuse `handle_reserved_name()` logic) -> `RenameError::ReservedName`
+  - New filename (stem + extension) exceeds `MAX_FILENAME_LENGTH` -> `RenameError::TooLong`
+- [ ] Build new path: same parent directory + `new_stem` + original extension
+- [ ] Check if new path already exists -> `RenameError::AlreadyExists(new_filename)`
+- [ ] Call `std::fs::rename(old_path, new_path)`
+- [ ] If backup exists (`backup::backup_path_for(old_path)`), rename backup too (best-effort, ignore errors)
+- [ ] Return `Ok(new_path)`
+
+**`src/files/filename.rs` -- New `RenameError` enum:**
+- [ ] `EmptyName`, `InvalidChars`, `ReservedName`, `TooLong`, `AlreadyExists(String)`, `IoError(std::io::Error)`
+
+**`src/tui/list_app.rs` -- New thin `rename_session()` method:**
+- [ ] Guard: `if let Some(item) = self.shared.explorer.selected_item()` (consistent with all other action methods)
+- [ ] Call `filename::rename_file(path, &self.rename_input)`
+- [ ] On success:
+  - Invalidate preview cache for old path
+  - Update explorer via `update_item_path()`
+  - Re-apply sort and filter (name change affects sort-by-name and search filter)
+  - Set status message: "Renamed to {new_name}"
+- [ ] On error: map `RenameError` variants to user-friendly status messages
+
+**`src/tui/widgets/file_explorer.rs` -- Fix `update_item_path()`:**
+- [ ] After updating item fields, call `apply_filter()` and `apply_sort()` to maintain correct ordering and filter state after name change
+
+**Tests in `src/files/filename.rs`:**
+- [ ] `rename_file_empty_name_errors`
+- [ ] `rename_file_same_name_is_noop`
+- [ ] `rename_file_success` (tempfile — verifies extension preserved)
+- [ ] `rename_file_renames_backup_too` (tempfile + .bak)
+- [ ] `rename_file_conflict_errors` (existing target)
+- [ ] `rename_file_invalid_chars_errors`
+- [ ] `rename_file_preserves_extension` (test with .cast, .txt, etc.)
+- [ ] `rename_file_reserved_name_errors` (CON, NUL, etc.)
+- [ ] `is_valid_filename_char_rejects_invalid`
+
+**Verify:** `cargo test files::filename && cargo test tui::list_app`
+
+---
+
+### Stage 4: Update Snapshot Tests
+
+**Goal**: Regenerate all affected snapshot tests and verify the final visual output.
+
+#### Changes
+
+- [ ] Run `cargo test --test snapshot_tui_test -- --force-update-snapshots` (or equivalent insta flag `INSTA_UPDATE=1`)
+- [ ] Review each updated snapshot for correctness:
+  - `context_menu_first_item.snap` -- Play selected, 7 items in new order, no silence hint
+  - `context_menu_last_item.snap` -- Delete selected (last item)
+  - `context_menu_delete_selected.snap` -- Delete highlighted
+  - `context_menu_restore_no_backup.snap` -- Restore with "no backup" suffix, no shortcut
+  - `context_menu_restore_with_backup.snap` -- Restore without shortcut
+  - `context_menu_transform_selected.snap` -- Optimize highlighted, no silence hint
+  - `help_modal.snap` -- includes `r Rename` line, no `m Add marker` line
+- [ ] Commit snapshot updates
+
+**Verify:** `cargo test --test snapshot_tui_test`
+
+---
+
+### Stage 5: Documentation Update
+
+**Goal**: Update module-level doc comments and the doc comment on the file.
+
+#### Changes
+
+- [ ] Update module doc comment at top of `src/tui/list_app.rs`: remove "add marker" from feature list, add "rename"
+- [ ] Review `README.md` TUI controls section: add `r` Rename, remove `m` Add marker if mentioned
+- [ ] Run `cargo xtask gen-docs` if applicable
+
+**Verify:** `cargo doc --no-deps`
+
+---
+
+## Dependencies
+
+```
+Stage 1 (Cleanup) ──> Stage 2 (Helpers + Mode + Keys) ──> Stage 3 (Filesystem Logic)
+                                                                  │
+                                                                  v
+                                                          Stage 4 (Snapshots)
+                                                                  │
+                                                                  v
+                                                          Stage 5 (Docs)
+```
+
+All stages are sequential. Stage 1 changes `ContextMenuItem::ALL` and item count. Stage 2 exposes validation helpers from `filename.rs` AND adds TUI mode/keys (both needed before Stage 3). Stage 3 adds `rename_file()` and wires it into `rename_session()`. Stages 4-5 finalize.
+
+---
+
+## Progress
+
+Updated by implementer as work progresses.
+
+| Stage | Status | Notes |
+|-------|--------|-------|
+| 1 | pending | Remove AddMarker, silence hint, reorder menu |
+| 2 | pending | Validation helpers + Mode::RenameInput + key handling + menu item |
+| 3 | pending | Filesystem rename logic |
+| 4 | pending | Snapshot test regeneration |
+| 5 | pending | Documentation |
+
+---
+
+## Test Commands
+
+```bash
+# Run list_app unit tests
+cargo test tui::list_app
+
+# Run snapshot TUI tests
+cargo test --test snapshot_tui_test
+
+# Run all TUI tests
+cargo test tui
+
+# Update snapshots (review diffs carefully)
+INSTA_UPDATE=1 cargo test --test snapshot_tui_test
+
+# Full test suite
+cargo test
+
+# Check for warnings/lints
+cargo clippy -- -D warnings
+```

--- a/.state/feature-ls-rename-action/PLAN.md
+++ b/.state/feature-ls-rename-action/PLAN.md
@@ -259,11 +259,11 @@ Updated by implementer as work progresses.
 
 | Stage | Status | Notes |
 |-------|--------|-------|
-| 1 | pending | Remove AddMarker, silence hint, reorder menu |
-| 2 | pending | Validation helpers + Mode::RenameInput + key handling + menu item |
-| 3 | pending | Filesystem rename logic |
-| 4 | pending | Snapshot test regeneration |
-| 5 | pending | Documentation |
+| 1 | done | Remove AddMarker, silence hint, reorder menu |
+| 2 | done | Validation helpers + Mode::RenameInput + key handling + menu item |
+| 3 | done | Filesystem rename logic |
+| 4 | done | Snapshot test regeneration (handled inline with stages 1-3) |
+| 5 | done | Documentation |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Use `agr list` or `agr ls` to open the interactive TUI for browsing recordings.
 | `d` | Delete recording |
 | `/` | Search by filename |
 | `f` | Filter by agent |
-| `Esc` | Clear filters |
+| `Esc` | Cancel / clear filters |
 | `?` | Show help overlay |
 | `q` | Quit browser |
 

--- a/README.md
+++ b/README.md
@@ -144,11 +144,15 @@ Use `agr list` or `agr ls` to open the interactive TUI for browsing recordings.
 
 | Key | Action |
 |-----|--------|
-| `Enter` | Play selected recording |
+| `Enter` | Open context menu |
+| `p` | Play selected recording |
 | `c` | Copy recording to clipboard |
-| `d` | Delete recording |
-| `e` | Explore recording in file viewer |
+| `r` | Rename recording |
+| `t` | Optimize (remove silence) |
 | `a` | Analyze recording with AI |
+| `d` | Delete recording |
+| `/` | Search by filename |
+| `f` | Filter by agent |
 | `?` | Show help overlay |
 | `q` / `Esc` | Quit browser |
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ Use `agr list` or `agr ls` to open the interactive TUI for browsing recordings.
 | `d` | Delete recording |
 | `/` | Search by filename |
 | `f` | Filter by agent |
+| `Esc` | Clear filters |
 | `?` | Show help overlay |
-| `q` / `Esc` | Quit browser |
+| `q` | Quit browser |
 
 ## Post-Processing Recordings
 

--- a/src/files/filename.rs
+++ b/src/files/filename.rs
@@ -39,13 +39,18 @@ const WINDOWS_RESERVED: &[&str] = &[
 ];
 
 /// Characters that are invalid in filenames on common filesystems.
-const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
+pub const INVALID_CHARS: &[char] = &['/', '\\', ':', '*', '?', '"', '<', '>', '|'];
 
 /// Default fallback name when sanitization produces an empty result.
 const FALLBACK_NAME: &str = "recording";
 
 /// Maximum filename length for most filesystems.
-const MAX_FILENAME_LENGTH: usize = 255;
+pub const MAX_FILENAME_LENGTH: usize = 255;
+
+/// Check whether a character is valid for use in filenames.
+pub fn is_valid_filename_char(c: char) -> bool {
+    !INVALID_CHARS.contains(&c)
+}
 
 /// Sanitizes a string for use in filenames.
 ///
@@ -119,7 +124,6 @@ pub fn sanitize_directory(input: &str, config: &Config) -> String {
 /// Validates that a final filename doesn't exceed filesystem limits.
 ///
 /// Returns an error if the filename exceeds 255 characters.
-#[allow(dead_code)]
 pub fn validate_length(filename: &str) -> Result<(), FilenameError> {
     if filename.len() > MAX_FILENAME_LENGTH {
         Err(FilenameError::TooLong {
@@ -451,6 +455,108 @@ impl std::fmt::Display for FilenameError {
 }
 
 impl std::error::Error for FilenameError {}
+
+/// Errors that can occur during file rename.
+#[derive(Debug)]
+pub enum RenameError {
+    /// New name is empty.
+    EmptyName,
+    /// New name contains invalid characters.
+    InvalidChars,
+    /// New name is a Windows reserved name.
+    ReservedName,
+    /// New filename exceeds filesystem length limit.
+    TooLong,
+    /// A file with the new name already exists.
+    AlreadyExists(String),
+    /// Filesystem I/O error.
+    IoError(std::io::Error),
+}
+
+impl std::fmt::Display for RenameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RenameError::EmptyName => write!(f, "Name cannot be empty"),
+            RenameError::InvalidChars => write!(f, "Name contains invalid characters"),
+            RenameError::ReservedName => write!(f, "Name is a reserved system name"),
+            RenameError::TooLong => write!(f, "Name is too long"),
+            RenameError::AlreadyExists(name) => write!(f, "File already exists: {}", name),
+            RenameError::IoError(e) => write!(f, "Rename failed: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for RenameError {}
+
+/// Rename a file on disk, preserving its original extension.
+///
+/// Validates the new stem, builds the new path in the same directory with
+/// the original extension, and performs the filesystem rename. If a backup
+/// file exists (via `backup_path_for`), it is renamed too (best-effort).
+///
+/// Returns the new path on success, or the original path if the name is unchanged.
+pub fn rename_file(
+    old_path: &std::path::Path,
+    new_stem: &str,
+) -> Result<std::path::PathBuf, RenameError> {
+    use crate::files::backup::backup_path_for;
+
+    // Validate: not empty
+    if new_stem.is_empty() {
+        return Err(RenameError::EmptyName);
+    }
+
+    // Validate: no invalid chars
+    if new_stem.chars().any(|c| !is_valid_filename_char(c)) {
+        return Err(RenameError::InvalidChars);
+    }
+
+    // Validate: not a Windows reserved name
+    let upper = new_stem.to_uppercase();
+    if WINDOWS_RESERVED.iter().any(|r| upper == *r) {
+        return Err(RenameError::ReservedName);
+    }
+
+    // Check if name is unchanged (no-op)
+    let current_stem = old_path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+    if new_stem == current_stem {
+        return Ok(old_path.to_path_buf());
+    }
+
+    // Build new filename preserving original extension
+    let ext = old_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let new_filename = if ext.is_empty() {
+        new_stem.to_string()
+    } else {
+        format!("{}.{}", new_stem, ext)
+    };
+
+    // Validate: total filename length
+    if new_filename.len() > MAX_FILENAME_LENGTH {
+        return Err(RenameError::TooLong);
+    }
+
+    // Build new path in same directory
+    let parent = old_path.parent().unwrap_or(std::path::Path::new("."));
+    let new_path = parent.join(&new_filename);
+
+    // Check for conflicts
+    if new_path.exists() {
+        return Err(RenameError::AlreadyExists(new_filename));
+    }
+
+    // Perform rename
+    std::fs::rename(old_path, &new_path).map_err(RenameError::IoError)?;
+
+    // Rename backup too (best-effort)
+    let old_backup = backup_path_for(old_path);
+    if old_backup.exists() {
+        let new_backup = backup_path_for(&new_path);
+        let _ = std::fs::rename(&old_backup, &new_backup);
+    }
+
+    Ok(new_path)
+}
 
 /// Errors that can occur during template parsing.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/files/filename.rs
+++ b/src/files/filename.rs
@@ -49,7 +49,7 @@ pub const MAX_FILENAME_LENGTH: usize = 255;
 
 /// Check whether a character is valid for use in filenames.
 pub fn is_valid_filename_char(c: char) -> bool {
-    !INVALID_CHARS.contains(&c)
+    !INVALID_CHARS.contains(&c) && !c.is_control()
 }
 
 /// Sanitizes a string for use in filenames.
@@ -501,8 +501,8 @@ pub fn rename_file(
 ) -> Result<std::path::PathBuf, RenameError> {
     use crate::files::backup::backup_path_for;
 
-    // Validate: not empty
-    if new_stem.is_empty() {
+    // Validate: not empty or whitespace-only
+    if new_stem.trim().is_empty() {
         return Err(RenameError::EmptyName);
     }
 

--- a/src/files/filename.rs
+++ b/src/files/filename.rs
@@ -511,8 +511,10 @@ pub fn rename_file(
         return Err(RenameError::InvalidChars);
     }
 
-    // Validate: not a Windows reserved name
-    let upper = new_stem.to_uppercase();
+    // Validate: not a Windows reserved name (check base before first dot,
+    // since Windows treats e.g. "CON.txt" the same as "CON")
+    let base_name = new_stem.split('.').next().unwrap_or(new_stem);
+    let upper = base_name.to_uppercase();
     if WINDOWS_RESERVED.iter().any(|r| upper == *r) {
         return Err(RenameError::ReservedName);
     }

--- a/src/tui/app/status_footer.rs
+++ b/src/tui/app/status_footer.rs
@@ -22,6 +22,16 @@ pub fn render_status_line(frame: &mut Frame, area: Rect, text: &str) {
     frame.render_widget(status, area);
 }
 
+/// Render a status line styled as an active input prompt.
+///
+/// Uses black text on accent background (highlight style) so that
+/// input modes like search and rename are visually distinct.
+pub fn render_input_line(frame: &mut Frame, area: Rect, text: &str) {
+    let theme = current_theme();
+    let status = Paragraph::new(text.to_string()).style(theme.highlight_style());
+    frame.render_widget(status, area);
+}
+
 /// Render a centered footer from a pre-formatted text string.
 ///
 /// Displays the text centered in the secondary text color of the current

--- a/src/tui/app/status_footer.rs
+++ b/src/tui/app/status_footer.rs
@@ -6,6 +6,7 @@
 use ratatui::{
     layout::{Alignment, Rect},
     style::Style,
+    text::{Line, Span},
     widgets::Paragraph,
     Frame,
 };
@@ -22,14 +23,15 @@ pub fn render_status_line(frame: &mut Frame, area: Rect, text: &str) {
     frame.render_widget(status, area);
 }
 
-/// Render a status line styled as an active input prompt.
-///
-/// Uses black text on accent background (highlight style) so that
-/// input modes like search and rename are visually distinct.
-pub fn render_input_line(frame: &mut Frame, area: Rect, text: &str) {
+/// Render a status line with a label in secondary style and the input
+/// value highlighted (black text on accent background).
+pub fn render_input_line(frame: &mut Frame, area: Rect, label: &str, value: &str) {
     let theme = current_theme();
-    let status = Paragraph::new(text.to_string()).style(theme.highlight_style());
-    frame.render_widget(status, area);
+    let line = Line::from(vec![
+        Span::styled(label, Style::default().fg(theme.text_secondary)),
+        Span::styled(value, theme.highlight_style()),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
 }
 
 /// Render a centered footer from a pre-formatted text string.

--- a/src/tui/cleanup_app.rs
+++ b/src/tui/cleanup_app.rs
@@ -465,30 +465,32 @@ impl TuiApp for CleanupApp {
             // Render file explorer with checkboxes (cleanup uses multi-select)
             render_explorer_list(frame, chunks[0], explorer, preview, true, false);
 
-            // Render status line — input modes use highlighted style and
-            // always take priority over status_message.
+            // Render status line — input modes highlight only the input
+            // value and always take priority over status_message.
             match mode {
                 Mode::Search => {
-                    let text = format!("Search: {}_", search_input);
-                    render_input_line(frame, chunks[1], &text);
+                    let value = format!("{}_", search_input);
+                    render_input_line(frame, chunks[1], "Search: ", &value);
                 }
                 Mode::GlobSelect => {
-                    let text = format!("Glob pattern: {}_", glob_input);
-                    render_input_line(frame, chunks[1], &text);
+                    let value = format!("{}_", glob_input);
+                    render_input_line(frame, chunks[1], "Glob pattern: ", &value);
                 }
                 Mode::AgentFilter => {
                     let agent = &available_agents[agent_filter_idx];
-                    let text = format!(
-                        "Filter by agent: {} (left/right to change, Enter to apply)",
-                        agent
+                    render_input_line(
+                        frame,
+                        chunks[1],
+                        "Filter by agent: ",
+                        &format!("{} (left/right to change, Enter to apply)", agent),
                     );
-                    render_input_line(frame, chunks[1], &text);
                 }
                 Mode::ConfirmDelete => {
                     render_input_line(
                         frame,
                         chunks[1],
-                        "Delete selected sessions? (y/n)",
+                        "Delete selected sessions? ",
+                        "(y/n)",
                     );
                 }
                 _ => {

--- a/src/tui/cleanup_app.rs
+++ b/src/tui/cleanup_app.rs
@@ -18,7 +18,7 @@ use ratatui::{
 use super::app::layout::build_explorer_layout;
 use super::app::list_view::render_explorer_list;
 use super::app::modals;
-use super::app::status_footer::{render_footer_text, render_status_line};
+use super::app::status_footer::{render_footer_text, render_input_line, render_status_line};
 use super::app::{handle_shared_key, App, KeyResult, SharedMode, SharedState, TuiApp};
 use super::widgets::preview::prefetch_adjacent_previews;
 use super::widgets::FileItem;
@@ -465,53 +465,70 @@ impl TuiApp for CleanupApp {
             // Render file explorer with checkboxes (cleanup uses multi-select)
             render_explorer_list(frame, chunks[0], explorer, preview, true, false);
 
-            // Render status line
-            let status_text = if let Some(msg) = &status {
-                msg.clone()
-            } else {
-                match mode {
-                    Mode::Search => format!("Search: {}_", search_input),
-                    Mode::GlobSelect => format!("Glob pattern: {}_", glob_input),
-                    Mode::AgentFilter => {
-                        let agent = &available_agents[agent_filter_idx];
-                        format!(
-                            "Filter by agent: {} (left/right to change, Enter to apply)",
-                            agent
-                        )
-                    }
-                    Mode::ConfirmDelete => String::new(), // Modal shows this
-                    Mode::Help => String::new(),
-                    Mode::Normal => {
-                        // Show selection info
-                        if selected_count > 0 {
-                            format!(
-                                "{} selected ({}) | {} total sessions",
-                                selected_count,
-                                format_size(selected_size),
-                                explorer.len()
-                            )
-                        } else {
-                            let mut parts = vec![];
-                            if let Some(search) = explorer.search_filter() {
-                                parts.push(format!("search: \"{}\"", search));
-                            }
-                            if let Some(agent) = explorer.agent_filter() {
-                                parts.push(format!("agent: {}", agent));
-                            }
-                            if parts.is_empty() {
-                                format!("{} sessions | Space to select", explorer.len())
-                            } else {
-                                format!(
-                                    "{} sessions ({}) | Space to select",
-                                    explorer.len(),
-                                    parts.join(", ")
-                                )
-                            }
-                        }
-                    }
+            // Render status line — input modes use highlighted style and
+            // always take priority over status_message.
+            match mode {
+                Mode::Search => {
+                    let text = format!("Search: {}_", search_input);
+                    render_input_line(frame, chunks[1], &text);
                 }
-            };
-            render_status_line(frame, chunks[1], &status_text);
+                Mode::GlobSelect => {
+                    let text = format!("Glob pattern: {}_", glob_input);
+                    render_input_line(frame, chunks[1], &text);
+                }
+                Mode::AgentFilter => {
+                    let agent = &available_agents[agent_filter_idx];
+                    let text = format!(
+                        "Filter by agent: {} (left/right to change, Enter to apply)",
+                        agent
+                    );
+                    render_input_line(frame, chunks[1], &text);
+                }
+                Mode::ConfirmDelete => {
+                    render_input_line(
+                        frame,
+                        chunks[1],
+                        "Delete selected sessions? (y/n)",
+                    );
+                }
+                _ => {
+                    let text = if let Some(msg) = &status {
+                        msg.clone()
+                    } else {
+                        match mode {
+                            Mode::Normal => {
+                                if selected_count > 0 {
+                                    format!(
+                                        "{} selected ({}) | {} total sessions",
+                                        selected_count,
+                                        format_size(selected_size),
+                                        explorer.len()
+                                    )
+                                } else {
+                                    let mut parts = vec![];
+                                    if let Some(search) = explorer.search_filter() {
+                                        parts.push(format!("search: \"{}\"", search));
+                                    }
+                                    if let Some(agent) = explorer.agent_filter() {
+                                        parts.push(format!("agent: {}", agent));
+                                    }
+                                    if parts.is_empty() {
+                                        format!("{} sessions | Space to select", explorer.len())
+                                    } else {
+                                        format!(
+                                            "{} sessions ({}) | Space to select",
+                                            explorer.len(),
+                                            parts.join(", ")
+                                        )
+                                    }
+                                }
+                            }
+                            _ => String::new(),
+                        }
+                    };
+                    render_status_line(frame, chunks[1], &text);
+                }
+            }
 
             // Render footer with keybindings
             let footer_text = match mode {

--- a/src/tui/event_bus.rs
+++ b/src/tui/event_bus.rs
@@ -53,11 +53,12 @@ impl EventHandler {
                         // Event available
                         match event::read() {
                             Ok(CrosstermEvent::Key(key)) => {
-                                // Check for quit keys
-                                if key.code == KeyCode::Char('q')
-                                    || key.code == KeyCode::Esc
-                                    || (key.code == KeyCode::Char('c')
-                                        && key.modifiers.contains(KeyModifiers::CONTROL))
+                                // Only Ctrl+C quits at the event-bus level.
+                                // q and Esc are forwarded as normal keys so
+                                // apps can handle them per-mode (e.g. cancel
+                                // rename, close dialog, or quit in Normal mode).
+                                if key.code == KeyCode::Char('c')
+                                    && key.modifiers.contains(KeyModifiers::CONTROL)
                                 {
                                     let _ = tx.send(Event::Quit);
                                     break;

--- a/src/tui/list_app.rs
+++ b/src/tui/list_app.rs
@@ -253,7 +253,9 @@ impl ListApp {
                 self.shared.agent_filter_idx = 0;
             }
 
-            // Quit is handled by EventHandler
+            // Quit
+            KeyCode::Char('q') => self.app.quit(),
+
             _ => {}
         }
         Ok(())

--- a/src/tui/list_app.rs
+++ b/src/tui/list_app.rs
@@ -747,7 +747,7 @@ impl ListApp {
 
         // Center the modal
         let modal_width = 60.min(area.width.saturating_sub(4));
-        let modal_height = 29.min(area.height.saturating_sub(4));
+        let modal_height = 31.min(area.height.saturating_sub(2));
         let x = (area.width - modal_width) / 2;
         let y = (area.height - modal_height) / 2;
         let modal_area = Rect::new(x, y, modal_width, modal_height);

--- a/src/tui/list_app.rs
+++ b/src/tui/list_app.rs
@@ -1141,37 +1141,39 @@ impl TuiApp for ListApp {
             // Render file explorer (no checkboxes in list view - it's single-select)
             render_explorer_list(frame, chunks[0], explorer, preview, false, backup_exists);
 
-            // Render status line — input modes use highlighted style and
-            // always take priority over status_message.
+            // Render status line — input modes highlight only the input
+            // value and always take priority over status_message.
             match mode {
                 Mode::Search => {
-                    let text = format!("Search: {}_", search_input);
-                    render_input_line(frame, chunks[1], &text);
+                    let value = format!("{}_", search_input);
+                    render_input_line(frame, chunks[1], "Search: ", &value);
                 }
                 Mode::AgentFilter => {
                     let agent = &available_agents[agent_filter_idx];
-                    let text = format!(
-                        "Filter by agent: {} (←/→ to change, Enter to apply)",
-                        agent
+                    render_input_line(
+                        frame,
+                        chunks[1],
+                        "Filter by agent: ",
+                        &format!("{} (←/→ to change, Enter to apply)", agent),
                     );
-                    render_input_line(frame, chunks[1], &text);
                 }
                 Mode::RenameInput => {
-                    let text = if rename_selected_all {
-                        format!("Rename: [{}]", rename_input)
+                    let value = if rename_selected_all {
+                        format!("[{}]", rename_input)
                     } else {
-                        format!("Rename: {}_", rename_input)
+                        format!("{}_", rename_input)
                     };
-                    render_input_line(frame, chunks[1], &text);
+                    render_input_line(frame, chunks[1], "Rename: ", &value);
                 }
                 Mode::ConfirmDelete => {
-                    render_input_line(frame, chunks[1], "Delete this session? (y/n)");
+                    render_input_line(frame, chunks[1], "Delete this session? ", "(y/n)");
                 }
                 Mode::ConfirmUnlock => {
                     render_input_line(
                         frame,
                         chunks[1],
-                        "This session is being recorded. Force unlock? (y/n)",
+                        "This session is being recorded. Force unlock? ",
+                        "(y/n)",
                     );
                 }
                 _ => {

--- a/src/tui/list_app.rs
+++ b/src/tui/list_app.rs
@@ -1,7 +1,7 @@
 //! List command TUI application
 //!
 //! Interactive file explorer for browsing and managing session recordings.
-//! Features: search, agent filter, play, delete, add marker.
+//! Features: search, agent filter, play, copy, rename, optimize, analyze, restore, delete.
 
 use std::path::Path;
 use std::time::Duration;
@@ -26,6 +26,7 @@ use super::widgets::FileItem;
 use crate::asciicast::{apply_transforms, TransformResult};
 use crate::config::Config;
 use crate::files::backup::{backup_path_for, create_backup, has_backup, restore_from_backup};
+use crate::files::filename;
 use crate::files::lock;
 use crate::theme::current_theme;
 
@@ -49,6 +50,8 @@ pub enum Mode {
     OptimizeResult,
     /// Confirm unlock mode - asking user to confirm force-unlock
     ConfirmUnlock,
+    /// Rename input mode - typing new filename
+    RenameInput,
 }
 
 impl Mode {
@@ -59,7 +62,9 @@ impl Mode {
             Mode::AgentFilter => Some(SharedMode::AgentFilter),
             Mode::Help => Some(SharedMode::Help),
             Mode::ConfirmDelete => Some(SharedMode::ConfirmDelete),
-            Mode::ContextMenu | Mode::OptimizeResult | Mode::ConfirmUnlock => None,
+            Mode::ContextMenu | Mode::OptimizeResult | Mode::ConfirmUnlock | Mode::RenameInput => {
+                None
+            }
         }
     }
 
@@ -79,11 +84,11 @@ impl Mode {
 pub enum ContextMenuItem {
     Play,
     Copy,
+    Rename,
     Optimize,
     Analyze,
     Restore,
     Delete,
-    AddMarker,
 }
 
 impl ContextMenuItem {
@@ -91,11 +96,11 @@ impl ContextMenuItem {
     pub const ALL: [ContextMenuItem; 7] = [
         ContextMenuItem::Play,
         ContextMenuItem::Copy,
+        ContextMenuItem::Rename,
         ContextMenuItem::Optimize,
         ContextMenuItem::Analyze,
         ContextMenuItem::Restore,
         ContextMenuItem::Delete,
-        ContextMenuItem::AddMarker,
     ];
 
     /// Get the display label for this menu item
@@ -103,11 +108,11 @@ impl ContextMenuItem {
         match self {
             ContextMenuItem::Play => "Play",
             ContextMenuItem::Copy => "Copy to clipboard",
+            ContextMenuItem::Rename => "Rename",
             ContextMenuItem::Optimize => "Optimize",
             ContextMenuItem::Analyze => "Analyze",
             ContextMenuItem::Restore => "Restore from backup",
             ContextMenuItem::Delete => "Delete",
-            ContextMenuItem::AddMarker => "Add marker",
         }
     }
 
@@ -116,12 +121,17 @@ impl ContextMenuItem {
         match self {
             ContextMenuItem::Play => "p",
             ContextMenuItem::Copy => "c",
+            ContextMenuItem::Rename => "r",
             ContextMenuItem::Optimize => "t",
             ContextMenuItem::Analyze => "a",
-            ContextMenuItem::Restore => "r",
+            ContextMenuItem::Restore => "",
             ContextMenuItem::Delete => "d",
-            ContextMenuItem::AddMarker => "m",
         }
+    }
+
+    /// Whether this menu item has a keyboard shortcut
+    pub fn has_shortcut(&self) -> bool {
+        !self.shortcut().is_empty()
     }
 }
 
@@ -146,6 +156,10 @@ pub struct ListApp {
     context_menu_idx: usize,
     /// Optimize result for modal display
     optimize_result: Option<OptimizeResultState>,
+    /// Rename input buffer (filename stem without extension)
+    rename_input: String,
+    /// Whether the entire rename input is "selected" (first keystroke replaces all)
+    rename_selected_all: bool,
 }
 
 impl ListApp {
@@ -160,6 +174,8 @@ impl ListApp {
             mode: Mode::Normal,
             context_menu_idx: 0,
             optimize_result: None,
+            rename_input: String::new(),
+            rename_selected_all: false,
         })
     }
 
@@ -214,6 +230,13 @@ impl ListApp {
                 }
                 self.analyze_session()?;
             }
+            KeyCode::Char('r') => {
+                if self.is_selected_locked() {
+                    self.mode = Mode::ConfirmUnlock;
+                    return Ok(());
+                }
+                self.enter_rename_mode();
+            }
             KeyCode::Char('d') => {
                 if self.is_selected_locked() {
                     self.mode = Mode::ConfirmUnlock;
@@ -223,14 +246,6 @@ impl ListApp {
                     self.mode = Mode::ConfirmDelete;
                 }
             }
-            KeyCode::Char('m') => {
-                if self.is_selected_locked() {
-                    self.mode = Mode::ConfirmUnlock;
-                    return Ok(());
-                }
-                self.add_marker()?;
-            }
-
             // Clear filters
             KeyCode::Esc => {
                 self.shared.explorer.clear_filters();
@@ -311,7 +326,7 @@ impl ListApp {
             KeyCode::Char('r') => {
                 self.context_menu_idx = ContextMenuItem::ALL
                     .iter()
-                    .position(|i| matches!(i, ContextMenuItem::Restore))
+                    .position(|i| matches!(i, ContextMenuItem::Rename))
                     .unwrap_or(0);
                 self.execute_context_menu_action()?;
             }
@@ -322,14 +337,6 @@ impl ListApp {
                     .unwrap_or(0);
                 self.execute_context_menu_action()?;
             }
-            KeyCode::Char('m') => {
-                self.context_menu_idx = ContextMenuItem::ALL
-                    .iter()
-                    .position(|i| matches!(i, ContextMenuItem::AddMarker))
-                    .unwrap_or(0);
-                self.execute_context_menu_action()?;
-            }
-
             // Close menu
             KeyCode::Esc => {
                 self.mode = Mode::Normal;
@@ -403,6 +410,7 @@ impl ListApp {
         match action {
             ContextMenuItem::Play => self.play_session()?,
             ContextMenuItem::Copy => self.copy_to_clipboard()?,
+            ContextMenuItem::Rename => self.enter_rename_mode(),
             ContextMenuItem::Optimize => self.optimize_session()?,
             ContextMenuItem::Analyze => self.analyze_session()?,
             ContextMenuItem::Restore => self.restore_session()?,
@@ -411,7 +419,6 @@ impl ListApp {
                     self.mode = Mode::ConfirmDelete;
                 }
             }
-            ContextMenuItem::AddMarker => self.add_marker()?,
         }
         Ok(())
     }
@@ -627,9 +634,101 @@ impl ListApp {
         Ok(())
     }
 
-    /// Add a marker to the selected session (placeholder).
-    fn add_marker(&mut self) -> Result<()> {
-        self.shared.status_message = Some("Marker feature coming soon!".to_string());
+    /// Enter rename input mode with current filename stem pre-filled.
+    fn enter_rename_mode(&mut self) {
+        if let Some(item) = self.shared.explorer.selected_item() {
+            let path = std::path::Path::new(&item.path);
+            let stem = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_string();
+            self.rename_input = stem;
+            self.rename_selected_all = true;
+            self.mode = Mode::RenameInput;
+        }
+    }
+
+    /// Handle keys in rename input mode.
+    fn handle_rename_input_key(&mut self, key: KeyEvent) -> Result<()> {
+        match key.code {
+            KeyCode::Esc => {
+                self.mode = Mode::Normal;
+            }
+            KeyCode::Enter => {
+                self.rename_session()?;
+                self.mode = Mode::Normal;
+            }
+            KeyCode::Backspace => {
+                if self.rename_selected_all {
+                    self.rename_input.clear();
+                    self.rename_selected_all = false;
+                } else {
+                    self.rename_input.pop();
+                }
+            }
+            KeyCode::Char(c) => {
+                if !filename::is_valid_filename_char(c) {
+                    return Ok(());
+                }
+                // Compute max stem length: MAX_FILENAME_LENGTH minus extension length
+                let ext_len = self
+                    .shared
+                    .explorer
+                    .selected_item()
+                    .map(|item| {
+                        std::path::Path::new(&item.path)
+                            .extension()
+                            .map(|e| e.len() + 1) // +1 for the dot
+                            .unwrap_or(0)
+                    })
+                    .unwrap_or(0);
+                let max_stem_len = filename::MAX_FILENAME_LENGTH.saturating_sub(ext_len);
+
+                if self.rename_selected_all {
+                    self.rename_input.clear();
+                    self.rename_input.push(c);
+                    self.rename_selected_all = false;
+                } else if self.rename_input.len() < max_stem_len {
+                    self.rename_input.push(c);
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// Rename the selected session file on disk.
+    fn rename_session(&mut self) -> Result<()> {
+        if let Some(item) = self.shared.explorer.selected_item() {
+            let path = std::path::Path::new(&item.path);
+            let old_path_str = item.path.clone();
+
+            match filename::rename_file(path, &self.rename_input) {
+                Ok(new_path) => {
+                    let new_path_str = new_path.to_string_lossy().to_string();
+                    if new_path_str != old_path_str {
+                        // Invalidate preview cache for old path
+                        self.shared.preview_cache.invalidate(&old_path_str);
+                        // Update explorer with new path
+                        self.shared
+                            .explorer
+                            .update_item_path(&old_path_str, &new_path_str);
+                        // Re-apply sort and filter since the name changed
+                        self.shared.explorer.apply_sort();
+                        self.shared.explorer.apply_filter();
+                        let new_name = new_path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("unknown");
+                        self.shared.status_message = Some(format!("Renamed to {}", new_name));
+                    }
+                }
+                Err(e) => {
+                    self.shared.status_message = Some(e.to_string());
+                }
+            }
+        }
         Ok(())
     }
 
@@ -640,7 +739,7 @@ impl ListApp {
 
         // Center the modal
         let modal_width = 60.min(area.width.saturating_sub(4));
-        let modal_height = 28.min(area.height.saturating_sub(4)); // Updated: added a for analyze
+        let modal_height = 29.min(area.height.saturating_sub(4));
         let x = (area.width - modal_width) / 2;
         let y = (area.height - modal_height) / 2;
         let modal_area = Rect::new(x, y, modal_width, modal_height);
@@ -690,6 +789,10 @@ impl ListApp {
             Line::from(vec![
                 Span::styled("  c", Style::default().fg(theme.accent)),
                 Span::raw("           Copy to clipboard"),
+            ]),
+            Line::from(vec![
+                Span::styled("  r", Style::default().fg(theme.accent)),
+                Span::raw("           Rename session"),
             ]),
             Line::from(vec![
                 Span::styled("  t", Style::default().fg(theme.accent)),
@@ -763,7 +866,7 @@ impl ListApp {
 
         // Center the modal
         let modal_width = 40.min(area.width.saturating_sub(4));
-        let modal_height = (ContextMenuItem::ALL.len() + 5) as u16; // items + title + padding + footer + optimize hint
+        let modal_height = (ContextMenuItem::ALL.len() + 4) as u16; // items + title + padding + footer
         let modal_height = modal_height.min(area.height.saturating_sub(4));
         let x = (area.width - modal_width) / 2;
         let y = (area.height - modal_height) / 2;
@@ -790,9 +893,15 @@ impl ListApp {
 
             // Build the label with shortcut hint
             let label = if is_restore && !backup_exists {
-                format!("  {} ({}) - no backup", item.label(), item.shortcut())
-            } else {
+                if item.has_shortcut() {
+                    format!("  {} ({}) - no backup", item.label(), item.shortcut())
+                } else {
+                    format!("  {} - no backup", item.label())
+                }
+            } else if item.has_shortcut() {
                 format!("  {} ({})", item.label(), item.shortcut())
+            } else {
+                format!("  {}", item.label())
             };
 
             let style = if is_selected {
@@ -809,14 +918,6 @@ impl ListApp {
                 format!("{}{}", prefix, label),
                 style,
             )));
-
-            // Add hint for Optimize
-            if matches!(item, ContextMenuItem::Optimize) {
-                lines.push(Line::from(Span::styled(
-                    "       Removes silence from recording",
-                    Style::default().fg(theme.text_secondary),
-                )));
-            }
         }
 
         lines.push(Line::from(""));
@@ -982,6 +1083,7 @@ impl TuiApp for ListApp {
             Mode::ContextMenu => self.handle_context_menu_key(key)?,
             Mode::OptimizeResult => self.handle_optimize_result_key(key)?,
             Mode::ConfirmUnlock => self.handle_confirm_unlock_key(key)?,
+            Mode::RenameInput => self.handle_rename_input_key(key)?,
             _ => {}
         }
         Ok(())
@@ -1007,6 +1109,8 @@ impl TuiApp for ListApp {
         let available_agents = &self.shared.available_agents;
         let context_menu_idx = self.context_menu_idx;
         let optimize_result = self.optimize_result.clone();
+        let rename_input = &self.rename_input;
+        let rename_selected_all = self.rename_selected_all;
 
         // Get preview for current selection from cache
         let current_path = explorer.selected_item().map(|i| i.path.clone());
@@ -1043,6 +1147,13 @@ impl TuiApp for ListApp {
                     Mode::ConfirmUnlock => {
                         "This session is being recorded. Force unlock? (y/n)".to_string()
                     }
+                    Mode::RenameInput => {
+                        if rename_selected_all {
+                            format!("Rename: [{}]", rename_input)
+                        } else {
+                            format!("Rename: {}_", rename_input)
+                        }
+                    }
                     Mode::Help => String::new(),
                     Mode::ContextMenu => String::new(),
                     Mode::OptimizeResult => String::new(),
@@ -1073,9 +1184,10 @@ impl TuiApp for ListApp {
                 Mode::ConfirmUnlock => "y: force unlock | n/Esc: cancel",
                 Mode::Help => "Press any key to close help",
                 Mode::ContextMenu => "↑↓: navigate | Enter: select | Esc: cancel",
+                Mode::RenameInput => "Enter: confirm | Esc: cancel | Backspace: delete char",
                 Mode::OptimizeResult => "Enter/Esc: dismiss",
                 Mode::Normal => {
-                    "↑↓: navigate | Enter: menu | p: play | c: copy | t: optimize | a: analyze | d: delete | ?: help | q: quit"
+                    "↑↓: navigate | Enter: menu | p: play | c: copy | r: rename | t: optimize | a: analyze | d: delete | ?: help | q: quit"
                 }
             };
             render_footer_text(frame, chunks[2], footer_text);
@@ -1180,8 +1292,13 @@ mod tests {
 
     #[test]
     fn context_menu_items_have_shortcuts() {
+        // All items except Restore have shortcuts
         for item in ContextMenuItem::ALL {
-            assert!(!item.shortcut().is_empty());
+            if matches!(item, ContextMenuItem::Restore) {
+                assert!(!item.has_shortcut());
+            } else {
+                assert!(item.has_shortcut());
+            }
         }
     }
 
@@ -1193,14 +1310,14 @@ mod tests {
 
     #[test]
     fn context_menu_item_order() {
-        // Verify expected order: Play, Copy, Optimize, Analyze, Restore, Delete, AddMarker
+        // Verify expected order: Play, Copy, Rename, Optimize, Analyze, Restore, Delete
         assert_eq!(ContextMenuItem::ALL[0], ContextMenuItem::Play);
         assert_eq!(ContextMenuItem::ALL[1], ContextMenuItem::Copy);
-        assert_eq!(ContextMenuItem::ALL[2], ContextMenuItem::Optimize);
-        assert_eq!(ContextMenuItem::ALL[3], ContextMenuItem::Analyze);
-        assert_eq!(ContextMenuItem::ALL[4], ContextMenuItem::Restore);
-        assert_eq!(ContextMenuItem::ALL[5], ContextMenuItem::Delete);
-        assert_eq!(ContextMenuItem::ALL[6], ContextMenuItem::AddMarker);
+        assert_eq!(ContextMenuItem::ALL[2], ContextMenuItem::Rename);
+        assert_eq!(ContextMenuItem::ALL[3], ContextMenuItem::Optimize);
+        assert_eq!(ContextMenuItem::ALL[4], ContextMenuItem::Analyze);
+        assert_eq!(ContextMenuItem::ALL[5], ContextMenuItem::Restore);
+        assert_eq!(ContextMenuItem::ALL[6], ContextMenuItem::Delete);
     }
 
     #[test]
@@ -1234,5 +1351,35 @@ mod tests {
     fn optimize_result_mode_exists() {
         assert_eq!(Mode::OptimizeResult, Mode::OptimizeResult);
         assert_ne!(Mode::OptimizeResult, Mode::Normal);
+    }
+
+    #[test]
+    fn rename_input_mode_exists() {
+        assert_eq!(Mode::RenameInput, Mode::RenameInput);
+        assert_ne!(Mode::RenameInput, Mode::Normal);
+    }
+
+    #[test]
+    fn rename_menu_item_label_and_shortcut() {
+        assert_eq!(ContextMenuItem::Rename.label(), "Rename");
+        assert_eq!(ContextMenuItem::Rename.shortcut(), "r");
+        assert!(ContextMenuItem::Rename.has_shortcut());
+    }
+
+    #[test]
+    fn is_valid_filename_char_rejects_invalid() {
+        for &c in filename::INVALID_CHARS {
+            assert!(!filename::is_valid_filename_char(c));
+        }
+    }
+
+    #[test]
+    fn is_valid_filename_char_accepts_valid() {
+        assert!(filename::is_valid_filename_char('a'));
+        assert!(filename::is_valid_filename_char('Z'));
+        assert!(filename::is_valid_filename_char('0'));
+        assert!(filename::is_valid_filename_char('-'));
+        assert!(filename::is_valid_filename_char('_'));
+        assert!(filename::is_valid_filename_char('.'));
     }
 }

--- a/src/tui/list_app.rs
+++ b/src/tui/list_app.rs
@@ -19,7 +19,7 @@ use ratatui::{
 use super::app::layout::build_explorer_layout;
 use super::app::list_view::render_explorer_list;
 use super::app::modals;
-use super::app::status_footer::{render_footer_text, render_status_line};
+use super::app::status_footer::{render_footer_text, render_input_line, render_status_line};
 use super::app::{handle_shared_key, App, KeyResult, SharedMode, SharedState, TuiApp};
 use super::widgets::preview::prefetch_adjacent_previews;
 use super::widgets::FileItem;
@@ -1141,48 +1141,64 @@ impl TuiApp for ListApp {
             // Render file explorer (no checkboxes in list view - it's single-select)
             render_explorer_list(frame, chunks[0], explorer, preview, false, backup_exists);
 
-            // Render status line
-            let status_text = if let Some(msg) = &status {
-                msg.clone()
-            } else {
-                match mode {
-                    Mode::Search => format!("Search: {}_", search_input),
-                    Mode::AgentFilter => {
-                        let agent = &available_agents[agent_filter_idx];
-                        format!("Filter by agent: {} (←/→ to change, Enter to apply)", agent)
-                    }
-                    Mode::ConfirmDelete => "Delete this session? (y/n)".to_string(),
-                    Mode::ConfirmUnlock => {
-                        "This session is being recorded. Force unlock? (y/n)".to_string()
-                    }
-                    Mode::RenameInput => {
-                        if rename_selected_all {
-                            format!("Rename: [{}]", rename_input)
-                        } else {
-                            format!("Rename: {}_", rename_input)
-                        }
-                    }
-                    Mode::Help => String::new(),
-                    Mode::ContextMenu => String::new(),
-                    Mode::OptimizeResult => String::new(),
-                    Mode::Normal => {
-                        // Show current filters if any
-                        let mut parts = vec![];
-                        if let Some(search) = explorer.search_filter() {
-                            parts.push(format!("search: \"{}\"", search));
-                        }
-                        if let Some(agent) = explorer.agent_filter() {
-                            parts.push(format!("agent: {}", agent));
-                        }
-                        if parts.is_empty() {
-                            format!("{} sessions", explorer.len())
-                        } else {
-                            format!("{} sessions ({})", explorer.len(), parts.join(", "))
-                        }
-                    }
+            // Render status line — input modes use highlighted style and
+            // always take priority over status_message.
+            match mode {
+                Mode::Search => {
+                    let text = format!("Search: {}_", search_input);
+                    render_input_line(frame, chunks[1], &text);
                 }
-            };
-            render_status_line(frame, chunks[1], &status_text);
+                Mode::AgentFilter => {
+                    let agent = &available_agents[agent_filter_idx];
+                    let text = format!(
+                        "Filter by agent: {} (←/→ to change, Enter to apply)",
+                        agent
+                    );
+                    render_input_line(frame, chunks[1], &text);
+                }
+                Mode::RenameInput => {
+                    let text = if rename_selected_all {
+                        format!("Rename: [{}]", rename_input)
+                    } else {
+                        format!("Rename: {}_", rename_input)
+                    };
+                    render_input_line(frame, chunks[1], &text);
+                }
+                Mode::ConfirmDelete => {
+                    render_input_line(frame, chunks[1], "Delete this session? (y/n)");
+                }
+                Mode::ConfirmUnlock => {
+                    render_input_line(
+                        frame,
+                        chunks[1],
+                        "This session is being recorded. Force unlock? (y/n)",
+                    );
+                }
+                _ => {
+                    let text = if let Some(msg) = &status {
+                        msg.clone()
+                    } else {
+                        match mode {
+                            Mode::Normal => {
+                                let mut parts = vec![];
+                                if let Some(search) = explorer.search_filter() {
+                                    parts.push(format!("search: \"{}\"", search));
+                                }
+                                if let Some(agent) = explorer.agent_filter() {
+                                    parts.push(format!("agent: {}", agent));
+                                }
+                                if parts.is_empty() {
+                                    format!("{} sessions", explorer.len())
+                                } else {
+                                    format!("{} sessions ({})", explorer.len(), parts.join(", "))
+                                }
+                            }
+                            _ => String::new(),
+                        }
+                    };
+                    render_status_line(frame, chunks[1], &text);
+                }
+            }
 
             // Render footer with keybindings
             let footer_text = match mode {

--- a/src/tui/list_app.rs
+++ b/src/tui/list_app.rs
@@ -656,8 +656,11 @@ impl ListApp {
                 self.mode = Mode::Normal;
             }
             KeyCode::Enter => {
-                self.rename_session()?;
-                self.mode = Mode::Normal;
+                let success = self.rename_session()?;
+                if success {
+                    self.mode = Mode::Normal;
+                }
+                // On error, stay in RenameInput so user can correct
             }
             KeyCode::Backspace => {
                 if self.rename_selected_all {
@@ -699,7 +702,10 @@ impl ListApp {
     }
 
     /// Rename the selected session file on disk.
-    fn rename_session(&mut self) -> Result<()> {
+    ///
+    /// Returns `true` on success (or no-op), `false` on error (so caller can
+    /// keep the user in rename mode for correction).
+    fn rename_session(&mut self) -> Result<bool> {
         if let Some(item) = self.shared.explorer.selected_item() {
             let path = std::path::Path::new(&item.path);
             let old_path_str = item.path.clone();
@@ -710,26 +716,26 @@ impl ListApp {
                     if new_path_str != old_path_str {
                         // Invalidate preview cache for old path
                         self.shared.preview_cache.invalidate(&old_path_str);
-                        // Update explorer with new path
+                        // Update explorer with new path and re-sort/re-filter
                         self.shared
                             .explorer
                             .update_item_path(&old_path_str, &new_path_str);
-                        // Re-apply sort and filter since the name changed
-                        self.shared.explorer.apply_sort();
-                        self.shared.explorer.apply_filter();
+                        self.shared.explorer.reindex_after_rename(&new_path_str);
                         let new_name = new_path
                             .file_name()
                             .and_then(|n| n.to_str())
                             .unwrap_or("unknown");
                         self.shared.status_message = Some(format!("Renamed to {}", new_name));
                     }
+                    return Ok(true);
                 }
                 Err(e) => {
                     self.shared.status_message = Some(e.to_string());
+                    return Ok(false);
                 }
             }
         }
-        Ok(())
+        Ok(true)
     }
 
     /// Render the help modal overlay.

--- a/src/tui/widgets/file_explorer.rs
+++ b/src/tui/widgets/file_explorer.rs
@@ -601,8 +601,16 @@ impl FileExplorer {
         self.sync_list_state();
     }
 
+    /// Re-sort and re-filter after an item rename, restoring selection to the given path.
+    pub(crate) fn reindex_after_rename(&mut self, new_path: &str) {
+        self.apply_filter();
+        self.apply_sort();
+        self.restore_selection_by_path(Some(new_path));
+        self.sync_list_state();
+    }
+
     /// Apply current sort to visible indices
-    pub fn apply_sort(&mut self) {
+    fn apply_sort(&mut self) {
         let items = &self.items;
         let dir = self.sort_direction;
 
@@ -698,7 +706,7 @@ impl FileExplorer {
     }
 
     /// Apply current filter to rebuild visible indices
-    pub fn apply_filter(&mut self) {
+    fn apply_filter(&mut self) {
         self.visible_indices = self
             .items
             .iter()
@@ -764,6 +772,7 @@ impl FileExplorer {
                 self.items[idx].size = metadata.len();
             }
             self.items[idx].has_backup = has_backup(new_p);
+            self.items[idx].lock_info = lock::read_lock(new_p);
             true
         } else {
             false

--- a/src/tui/widgets/file_explorer.rs
+++ b/src/tui/widgets/file_explorer.rs
@@ -602,7 +602,7 @@ impl FileExplorer {
     }
 
     /// Apply current sort to visible indices
-    fn apply_sort(&mut self) {
+    pub fn apply_sort(&mut self) {
         let items = &self.items;
         let dir = self.sort_direction;
 
@@ -698,7 +698,7 @@ impl FileExplorer {
     }
 
     /// Apply current filter to rebuild visible indices
-    fn apply_filter(&mut self) {
+    pub fn apply_filter(&mut self) {
         self.visible_indices = self
             .items
             .iter()

--- a/tests/integration/filename_test.rs
+++ b/tests/integration/filename_test.rs
@@ -2116,3 +2116,140 @@ fn first_word_result_never_shorter_than_syllable() {
         );
     }
 }
+
+// ============================================================================
+// Rename File Tests
+// ============================================================================
+
+use agr::files::filename::RenameError;
+use tempfile::TempDir;
+
+#[test]
+fn rename_file_empty_name_errors() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("old.cast");
+    std::fs::write(&file, "test").unwrap();
+
+    let result = filename::rename_file(&file, "");
+    assert!(matches!(result, Err(RenameError::EmptyName)));
+}
+
+#[test]
+fn rename_file_same_name_is_noop() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("old.cast");
+    std::fs::write(&file, "test").unwrap();
+
+    let result = filename::rename_file(&file, "old").unwrap();
+    assert_eq!(result, file);
+    assert!(file.exists());
+}
+
+#[test]
+fn rename_file_success() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("old.cast");
+    std::fs::write(&file, "test content").unwrap();
+
+    let result = filename::rename_file(&file, "new-name").unwrap();
+    assert_eq!(result, dir.path().join("new-name.cast"));
+    assert!(!file.exists());
+    assert!(result.exists());
+    assert_eq!(std::fs::read_to_string(&result).unwrap(), "test content");
+}
+
+#[test]
+fn rename_file_preserves_extension() {
+    let dir = TempDir::new().unwrap();
+
+    // Test with .cast extension
+    let cast_file = dir.path().join("session.cast");
+    std::fs::write(&cast_file, "cast").unwrap();
+    let result = filename::rename_file(&cast_file, "renamed").unwrap();
+    assert_eq!(result.extension().unwrap(), "cast");
+
+    // Test with .txt extension
+    let txt_file = dir.path().join("notes.txt");
+    std::fs::write(&txt_file, "txt").unwrap();
+    let result = filename::rename_file(&txt_file, "renamed-notes").unwrap();
+    assert_eq!(result.extension().unwrap(), "txt");
+}
+
+#[test]
+fn rename_file_renames_backup_too() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("session.cast");
+    let backup = dir.path().join("session.cast.bak");
+    std::fs::write(&file, "main").unwrap();
+    std::fs::write(&backup, "backup").unwrap();
+
+    let result = filename::rename_file(&file, "renamed").unwrap();
+    assert_eq!(result, dir.path().join("renamed.cast"));
+
+    let new_backup = dir.path().join("renamed.cast.bak");
+    assert!(new_backup.exists());
+    assert!(!backup.exists());
+    assert_eq!(std::fs::read_to_string(&new_backup).unwrap(), "backup");
+}
+
+#[test]
+fn rename_file_conflict_errors() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("old.cast");
+    let conflict = dir.path().join("existing.cast");
+    std::fs::write(&file, "old").unwrap();
+    std::fs::write(&conflict, "existing").unwrap();
+
+    let result = filename::rename_file(&file, "existing");
+    assert!(matches!(result, Err(RenameError::AlreadyExists(_))));
+    // Original file should still exist
+    assert!(file.exists());
+}
+
+#[test]
+fn rename_file_invalid_chars_errors() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("old.cast");
+    std::fs::write(&file, "test").unwrap();
+
+    let result = filename::rename_file(&file, "bad/name");
+    assert!(matches!(result, Err(RenameError::InvalidChars)));
+
+    let result = filename::rename_file(&file, "bad:name");
+    assert!(matches!(result, Err(RenameError::InvalidChars)));
+}
+
+#[test]
+fn rename_file_reserved_name_errors() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("old.cast");
+    std::fs::write(&file, "test").unwrap();
+
+    let result = filename::rename_file(&file, "CON");
+    assert!(matches!(result, Err(RenameError::ReservedName)));
+
+    let result = filename::rename_file(&file, "nul");
+    assert!(matches!(result, Err(RenameError::ReservedName)));
+}
+
+#[test]
+fn is_valid_filename_char_rejects_invalid() {
+    for &c in filename::INVALID_CHARS {
+        assert!(
+            !filename::is_valid_filename_char(c),
+            "Should reject '{}'",
+            c
+        );
+    }
+}
+
+#[test]
+fn is_valid_filename_char_accepts_normal_chars() {
+    assert!(filename::is_valid_filename_char('a'));
+    assert!(filename::is_valid_filename_char('Z'));
+    assert!(filename::is_valid_filename_char('0'));
+    assert!(filename::is_valid_filename_char('-'));
+    assert!(filename::is_valid_filename_char('_'));
+    assert!(filename::is_valid_filename_char('.'));
+    assert!(filename::is_valid_filename_char(' '));
+}

--- a/tests/integration/filename_test.rs
+++ b/tests/integration/filename_test.rs
@@ -2253,3 +2253,26 @@ fn is_valid_filename_char_accepts_normal_chars() {
     assert!(filename::is_valid_filename_char('.'));
     assert!(filename::is_valid_filename_char(' '));
 }
+
+#[test]
+fn is_valid_filename_char_rejects_control_chars() {
+    assert!(!filename::is_valid_filename_char('\0'));
+    assert!(!filename::is_valid_filename_char('\n'));
+    assert!(!filename::is_valid_filename_char('\t'));
+    assert!(!filename::is_valid_filename_char('\r'));
+    assert!(!filename::is_valid_filename_char('\x1b')); // ESC
+    assert!(!filename::is_valid_filename_char('\x7f')); // DEL
+}
+
+#[test]
+fn rename_file_whitespace_only_name_errors() {
+    let dir = TempDir::new().unwrap();
+    let file = dir.path().join("old.cast");
+    std::fs::write(&file, "test").unwrap();
+
+    let result = filename::rename_file(&file, "   ");
+    assert!(matches!(result, Err(RenameError::EmptyName)));
+
+    let result = filename::rename_file(&file, " ");
+    assert!(matches!(result, Err(RenameError::EmptyName)));
+}

--- a/tests/integration/filename_test.rs
+++ b/tests/integration/filename_test.rs
@@ -2230,6 +2230,10 @@ fn rename_file_reserved_name_errors() {
 
     let result = filename::rename_file(&file, "nul");
     assert!(matches!(result, Err(RenameError::ReservedName)));
+
+    // Dotted stems like "CON.txt" are also reserved on Windows
+    let result = filename::rename_file(&file, "CON.txt");
+    assert!(matches!(result, Err(RenameError::ReservedName)));
 }
 
 #[test]

--- a/tests/integration/snapshot_tui_test.rs
+++ b/tests/integration/snapshot_tui_test.rs
@@ -718,25 +718,25 @@ fn snapshot_context_menu_first_item_selected() {
 
 #[test]
 fn snapshot_context_menu_transform_selected() {
-    let output = render_context_menu_to_string(1, true);
+    let output = render_context_menu_to_string(3, true);
     insta::assert_snapshot!("context_menu_transform_selected", output);
 }
 
 #[test]
 fn snapshot_context_menu_restore_selected_with_backup() {
-    let output = render_context_menu_to_string(2, true);
+    let output = render_context_menu_to_string(5, true);
     insta::assert_snapshot!("context_menu_restore_with_backup", output);
 }
 
 #[test]
 fn snapshot_context_menu_restore_selected_no_backup() {
-    let output = render_context_menu_to_string(2, false);
+    let output = render_context_menu_to_string(5, false);
     insta::assert_snapshot!("context_menu_restore_no_backup", output);
 }
 
 #[test]
 fn snapshot_context_menu_delete_selected() {
-    let output = render_context_menu_to_string(5, true);
+    let output = render_context_menu_to_string(6, true);
     insta::assert_snapshot!("context_menu_delete_selected", output);
 }
 

--- a/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_delete_selected.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_delete_selected.snap
@@ -10,10 +10,9 @@ expression: output
           │                                      │          
           │    Play (p)                          │          
           │    Copy to clipboard (c)             │          
+          │    Rename (r)                        │          
           │    Optimize (t)                      │          
-          │       Removes silence from recording │          
           │    Analyze (a)                       │          
-          │    Restore from backup (r)           │          
+          │    Restore from backup               │          
           │>   Delete (d)                        │          
-          │    Add marker (m)                    │          
           └──────────────────────────────────────┘

--- a/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_first_item.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_first_item.snap
@@ -10,10 +10,9 @@ expression: output
           │                                      │          
           │>   Play (p)                          │          
           │    Copy to clipboard (c)             │          
+          │    Rename (r)                        │          
           │    Optimize (t)                      │          
-          │       Removes silence from recording │          
           │    Analyze (a)                       │          
-          │    Restore from backup (r)           │          
+          │    Restore from backup               │          
           │    Delete (d)                        │          
-          │    Add marker (m)                    │          
           └──────────────────────────────────────┘

--- a/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_last_item.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_last_item.snap
@@ -10,10 +10,9 @@ expression: output
           │                                      │          
           │    Play (p)                          │          
           │    Copy to clipboard (c)             │          
+          │    Rename (r)                        │          
           │    Optimize (t)                      │          
-          │       Removes silence from recording │          
           │    Analyze (a)                       │          
-          │    Restore from backup (r)           │          
-          │    Delete (d)                        │          
-          │>   Add marker (m)                    │          
+          │    Restore from backup               │          
+          │>   Delete (d)                        │          
           └──────────────────────────────────────┘

--- a/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_restore_no_backup.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_restore_no_backup.snap
@@ -10,10 +10,9 @@ expression: output
           │                                      │          
           │    Play (p)                          │          
           │    Copy to clipboard (c)             │          
-          │>   Optimize (t)                      │          
-          │       Removes silence from recording │          
+          │    Rename (r)                        │          
+          │    Optimize (t)                      │          
           │    Analyze (a)                       │          
-          │    Restore from backup (r) - no backu│          
+          │>   Restore from backup - no backup   │          
           │    Delete (d)                        │          
-          │    Add marker (m)                    │          
           └──────────────────────────────────────┘

--- a/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_restore_with_backup.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_restore_with_backup.snap
@@ -10,10 +10,9 @@ expression: output
           │                                      │          
           │    Play (p)                          │          
           │    Copy to clipboard (c)             │          
-          │>   Optimize (t)                      │          
-          │       Removes silence from recording │          
+          │    Rename (r)                        │          
+          │    Optimize (t)                      │          
           │    Analyze (a)                       │          
-          │    Restore from backup (r)           │          
+          │>   Restore from backup               │          
           │    Delete (d)                        │          
-          │    Add marker (m)                    │          
           └──────────────────────────────────────┘

--- a/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_transform_selected.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__context_menu_transform_selected.snap
@@ -9,11 +9,10 @@ expression: output
           │Actions                               │          
           │                                      │          
           │    Play (p)                          │          
-          │>   Copy to clipboard (c)             │          
-          │    Optimize (t)                      │          
-          │       Removes silence from recording │          
+          │    Copy to clipboard (c)             │          
+          │    Rename (r)                        │          
+          │>   Optimize (t)                      │          
           │    Analyze (a)                       │          
-          │    Restore from backup (r)           │          
+          │    Restore from backup               │          
           │    Delete (d)                        │          
-          │    Add marker (m)                    │          
           └──────────────────────────────────────┘

--- a/tests/integration/snapshots/integration__snapshot_tui_test__help_modal.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__help_modal.snap
@@ -3,7 +3,6 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
                                                                       
-                                                                      
      ┌ Help ────────────────────────────────────────────────────┐     
      │Keyboard Shortcuts                                        │     
      │                                                          │     
@@ -28,5 +27,7 @@ expression: output
      │                                                          │     
      │  ?           This help                                   │     
      │  q           Quit                                        │     
+     │                                                          │     
+     │Press any key to close                                    │     
      │                                                          │     
      └──────────────────────────────────────────────────────────┘

--- a/tests/integration/snapshots/integration__snapshot_tui_test__help_modal.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__help_modal.snap
@@ -16,6 +16,7 @@ expression: output
      │  Enter       Context menu                                │     
      │  p           Play session                                │     
      │  c           Copy to clipboard                           │     
+     │  r           Rename session                              │     
      │  t           Optimize (removes silence)                  │     
      │  a           Analyze session                             │     
      │  d           Delete session                              │     
@@ -28,5 +29,4 @@ expression: output
      │  ?           This help                                   │     
      │  q           Quit                                        │     
      │                                                          │     
-     │Press any key to close                                    │     
      └──────────────────────────────────────────────────────────┘


### PR DESCRIPTION
## Summary

- **Rename action** for `agr ls` TUI — press `r` or use the context menu to rename recordings inline
- **Event bus fix** — Esc and q keys now forwarded to app handlers instead of always quitting; only Ctrl+C quits at the event-bus level
- **Input mode highlighting** — search, rename, filter, and confirmation prompts use accent-colored input values (black on green) so they're visually distinct and never hidden by stale status messages
- **Rename validation** — rejects empty/whitespace-only names, control characters, Windows reserved names (including dotted like CON.txt), and enforces filesystem length limits

## ADR

[`.state/feature-ls-rename-action/ADR.md`](.state/feature-ls-rename-action/ADR.md)

## Test plan

- [x] Unit tests: `cargo test` (all 789+ pass)
- [x] Clippy: `cargo clippy -- -D warnings` (clean)
- [x] Snapshot tests regenerated and verified
- [x] Manual testing confirmed by user
- [x] Internal review: 2 rounds, all findings addressed
- [x] CodeRabbit review: 1 finding (dotted reserved names), addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)