### PR TITLE
chore(docs): update filename template documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,8 @@ Customize how recording filenames are generated using template tags:
 
 ```toml
 [recording]
-filename_template = "{directory}_{date}_{time}"  # Default
-directory_max_length = 50                         # Truncate long directory names
+filename_template = "{directory}{?branch}_{id}"  # Default
+directory_max_length = 14                         # Truncate long directory names
 ```
 
 **Available tags:**
@@ -212,22 +212,28 @@ directory_max_length = 50                         # Truncate long directory name
 | Tag | Description | Example Output |
 |-----|-------------|----------------|
 | `{directory}` | Current working directory name | `my-project` |
+| `{?branch}` | Optional git branch (wrapped in parens) | `(feature--login)` or empty |
+| `{branch}` | Git branch name (sanitized) | `feature--login` |
+| `{id}` | Base36 epoch timestamp (7 chars, sortable) | `0ta73n2` |
 | `{date}` | Date in YYMMDD format | `260129` |
 | `{date:FORMAT}` | Date with custom strftime | `{date:%Y-%m-%d}` → `2026-01-29` |
-| `{time}` | Time in HHMMSS format | `143022` |
+| `{time}` | Time in HHMM format | `1430` |
 | `{time:FORMAT}` | Time with custom strftime | `{time:%H:%M}` → `14:30` |
 
 **Example configurations:**
 
 ```toml
-# Default: project_260129_143022.cast
-filename_template = "{directory}_{date}_{time}"
+# Default: project(feature--login)_0ta73n2.cast
+filename_template = "{directory}{?branch}_{id}"
+
+# Branch + date: project_main_260129.cast
+filename_template = "{directory}_{branch}_{date}"
 
 # ISO date: project_2026-01-29.cast
 filename_template = "{directory}_{date:%Y-%m-%d}"
 
-# Simple timestamp: 260129-1430.cast (minutes only)
-filename_template = "{date:%y%m%d}-{time:%H%M}"
+# Simple ID only: 0ta73n2.cast
+filename_template = "{id}"
 ```
 
 See the [Wiki](../../wiki) for full configuration reference.

--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -39,7 +39,7 @@ Recording behavior settings
 | Option | Default | Description |
 |--------|---------|-------------|
 | `auto_analyze` | `false` | Automatically run AI analysis after recording ends |
-| `filename_template` | `{directory}_{date}_{time}` | Filename template using {directory}, {date}, {time} tags |
+| `filename_template` | `{directory}{?branch}_{id}` | Filename template using {directory}, {?branch}, {id}, {branch}, {date}, {time} tags |
 | `directory_max_length` | `14` | Maximum characters for directory component in filename |
 
 ### [analysis]
@@ -84,6 +84,9 @@ Customize how recording filenames are generated using template tags.
 | Tag | Description | Example Output |
 |-----|-------------|----------------|
 | `{directory}` | Current working directory name | `my-project` |
+| `{?branch}` | Optional git branch (wrapped in parens) | `(feature--login)` or empty |
+| `{branch}` | Git branch name (sanitized) | `feature--login` |
+| `{id}` | Base36 epoch timestamp (7 chars, sortable) | `0ta73n2` |
 | `{date}` | Date in YYMMDD format | `260129` |
 | `{date:FORMAT}` | Date with custom strftime | `{date:%Y-%m-%d}` → `2026-01-29` |
 | `{time}` | Time in HHMM format | `1430` |
@@ -93,14 +96,17 @@ Customize how recording filenames are generated using template tags.
 
 ```toml
 [recording]
-# Default: project_260129_1430.cast
-filename_template = "{directory}_{date}_{time}"
+# Default: project(feature--login)_0ta73n2.cast
+filename_template = "{directory}{?branch}_{id}"
+
+# Branch + date: project_main_260129.cast
+filename_template = "{directory}_{branch}_{date}"
 
 # ISO date: project_2026-01-29.cast
 filename_template = "{directory}_{date:%Y-%m-%d}"
 
-# Simple timestamp: 260129-143022.cast
-filename_template = "{date:%y%m%d}-{time:%H%M%S}"
+# Simple ID only: 0ta73n2.cast
+filename_template = "{id}"
 ```
 
 ### Sanitization

--- a/src/config/docs.rs
+++ b/src/config/docs.rs
@@ -69,8 +69,8 @@ pub const CONFIG_SECTIONS: &[SectionDoc] = &[
             },
             FieldDoc {
                 name: "filename_template",
-                description: "Filename template using {directory}, {date}, {time} tags",
-                default_display: "{directory}_{date}_{time}",
+                description: "Filename template using {directory}, {?branch}, {id}, {branch}, {date}, {time} tags",
+                default_display: "{directory}{?branch}_{id}",
             },
             FieldDoc {
                 name: "directory_max_length",
@@ -362,6 +362,11 @@ pub fn generate_config_markdown() -> String {
     md.push_str("| Tag | Description | Example Output |\n");
     md.push_str("|-----|-------------|----------------|\n");
     md.push_str("| `{directory}` | Current working directory name | `my-project` |\n");
+    md.push_str(
+        "| `{?branch}` | Optional git branch (wrapped in parens) | `(feature--login)` or empty |\n",
+    );
+    md.push_str("| `{branch}` | Git branch name (sanitized) | `feature--login` |\n");
+    md.push_str("| `{id}` | Base36 epoch timestamp (7 chars, sortable) | `0ta73n2` |\n");
     md.push_str("| `{date}` | Date in YYMMDD format | `260129` |\n");
     md.push_str(
         "| `{date:FORMAT}` | Date with custom strftime | `{date:%Y-%m-%d}` → `2026-01-29` |\n",
@@ -373,12 +378,14 @@ pub fn generate_config_markdown() -> String {
     md.push_str("### Example Templates\n\n");
     md.push_str("```toml\n");
     md.push_str("[recording]\n");
-    md.push_str("# Default: project_260129_1430.cast\n");
-    md.push_str("filename_template = \"{directory}_{date}_{time}\"\n\n");
+    md.push_str("# Default: project(feature--login)_0ta73n2.cast\n");
+    md.push_str("filename_template = \"{directory}{?branch}_{id}\"\n\n");
+    md.push_str("# Branch + date: project_main_260129.cast\n");
+    md.push_str("filename_template = \"{directory}_{branch}_{date}\"\n\n");
     md.push_str("# ISO date: project_2026-01-29.cast\n");
     md.push_str("filename_template = \"{directory}_{date:%Y-%m-%d}\"\n\n");
-    md.push_str("# Simple timestamp: 260129-143022.cast\n");
-    md.push_str("filename_template = \"{date:%y%m%d}-{time:%H%M%S}\"\n");
+    md.push_str("# Simple ID only: 0ta73n2.cast\n");
+    md.push_str("filename_template = \"{id}\"\n");
     md.push_str("```\n\n");
 
     md.push_str("### Sanitization\n\n");


### PR DESCRIPTION
## Summary
- Updated docs to reflect the new default template `{directory}{?branch}_{id}` (was `{directory}_{date}_{time}`)
- Added `{?branch}`, `{branch}`, and `{id}` tags to the available tags table
- Updated example configurations in README, `config/docs.rs`, and regenerated wiki

## Test plan
- [x] Full test suite passes
- [x] Wiki regenerated via `cargo xtask gen-docs --wiki`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded filename template configuration documentation with three new template tags: {?branch}, {branch}, and {id}.
  * Updated template examples and default configurations to showcase new tagging combinations for greater customization flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->