### PR TITLE
chore(storage): improve list sorting and smart time display

### DIFF
--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -113,13 +113,11 @@ fn handle_text(
     // Print table header
     println!(
         "{}",
-        theme.primary_text("  #  |     When | Agent       | Size       | Filename")
+        theme.primary_text("  #  | When  | Agent       | Size       | Filename")
     );
     println!(
         "{}",
-        theme.primary_text(
-            "-----+----------+-------------+------------+---------------------------"
-        )
+        theme.primary_text("-----+-------+-------------+------------+---------------------------")
     );
 
     // Display sessions in formatted table
@@ -127,7 +125,7 @@ fn handle_text(
         println!(
             "{}",
             theme.primary_text(&format!(
-                "{:>3}  | {:>8} | {:11} | {:>10} | {}",
+                "{:>3}  | {:>5} | {:11} | {:>10} | {}",
                 i + 1,
                 format_smart_time(&session.modified),
                 truncate_string(&session.agent, 11),

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -4,6 +4,7 @@ use std::io::IsTerminal;
 
 use anyhow::Result;
 
+use agr::storage::format_smart_time;
 use agr::theme::current_theme;
 use agr::tui::app::TuiApp;
 use agr::tui::widgets::FileItem;
@@ -65,14 +66,11 @@ fn handle_tui(
 
 /// Handle list command with text output (piped mode fallback).
 fn handle_text(
-    mut sessions: Vec<agr::storage::SessionInfo>,
+    sessions: Vec<agr::storage::SessionInfo>,
     agent: Option<&str>,
     storage: &StorageManager,
 ) -> Result<()> {
     let theme = current_theme();
-
-    // Reverse to show newest first
-    sessions.reverse();
 
     // Print summary header
     if let Some(agent_name) = &agent {
@@ -115,12 +113,12 @@ fn handle_text(
     // Print table header
     println!(
         "{}",
-        theme.primary_text("  #  |  Age  | DateTime         | Agent       | Size       | Filename")
+        theme.primary_text("  #  |     When | Agent       | Size       | Filename")
     );
     println!(
         "{}",
         theme.primary_text(
-            "-----+-------+------------------+-------------+------------+---------------------------"
+            "-----+----------+-------------+------------+---------------------------"
         )
     );
 
@@ -129,10 +127,9 @@ fn handle_text(
         println!(
             "{}",
             theme.primary_text(&format!(
-                "{:>3}  | {:>5} | {} | {:11} | {:>10} | {}",
+                "{:>3}  | {:>8} | {:11} | {:>10} | {}",
                 i + 1,
-                session.format_age(),
-                session.modified.format("%Y-%m-%d %H:%M"),
+                format_smart_time(&session.modified),
                 truncate_string(&session.agent, 11),
                 session.size_human(),
                 session.filename

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,13 +1,53 @@
 //! Storage management for recorded sessions
 
 use anyhow::{Context, Result};
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Datelike, Local};
 use humansize::{format_size, BINARY};
 use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
 use crate::config::Config;
+
+/// Format a timestamp as a smart time prefix:
+/// - Today:      `14:05:30` (H:M:S)
+/// - Yesterday:  `23h`      (hours ago)
+/// - Same year:  `01.02`    (DD.MM)
+/// - Older:      `1y5m`     (years and months ago)
+pub fn format_smart_time(modified: &DateTime<Local>) -> String {
+    let now = Local::now();
+    let duration = now.signed_duration_since(*modified);
+    let hours = duration.num_hours();
+
+    if duration.num_seconds() < 0 {
+        // Future timestamp — just show time
+        return modified.format("%-H:%M:%S").to_string();
+    }
+
+    if hours < 24 && now.date_naive() == modified.date_naive() {
+        // Today — show H:M:S
+        modified.format("%-H:%M:%S").to_string()
+    } else if hours < 48 {
+        // Yesterday — show hours
+        format!("{}h", hours)
+    } else if modified.year() == now.year() {
+        // Same year — show DD.MM
+        modified.format("%d.%m").to_string()
+    } else {
+        // Older — show relative years and months
+        let mut years = now.year() - modified.year();
+        let mut months = now.month() as i32 - modified.month() as i32;
+        if months < 0 {
+            years -= 1;
+            months += 12;
+        }
+        if years > 0 {
+            format!("{}y{}m", years, months)
+        } else {
+            format!("{}m", months)
+        }
+    }
+}
 
 /// Information about a recorded session
 #[derive(Debug, Clone)]
@@ -26,6 +66,22 @@ impl SessionInfo {
     /// Get human-readable size
     pub fn size_human(&self) -> String {
         format_size(self.size, BINARY)
+    }
+
+    /// Return a sort key: filename with optional branch `(...)` stripped,
+    /// so `project(branch)_id` and `project_id` sort together.
+    pub fn sort_key(&self) -> String {
+        let mut result = String::with_capacity(self.filename.len());
+        let mut in_parens = false;
+        for c in self.filename.chars() {
+            match c {
+                '(' => in_parens = true,
+                ')' if in_parens => in_parens = false,
+                _ if !in_parens => result.push(c),
+                _ => {}
+            }
+        }
+        result.to_lowercase()
     }
 
     /// Format age for display - smart format based on age
@@ -199,8 +255,26 @@ impl StorageManager {
             }
         }
 
-        // Sort by modification time (oldest first)
-        sessions.sort_by(|a, b| a.modified.cmp(&b.modified));
+        // Group by project, ordered by most recent activity per project, newest first within each group
+        // 1. Find the newest modified time per project (sort_key)
+        let mut project_latest: std::collections::HashMap<String, DateTime<Local>> =
+            std::collections::HashMap::new();
+        for s in &sessions {
+            let key = s.sort_key();
+            let entry = project_latest.entry(key).or_insert(s.modified);
+            if s.modified > *entry {
+                *entry = s.modified;
+            }
+        }
+        // 2. Sort: most recently active project first, then newest within each project
+        sessions.sort_by(|a, b| {
+            let a_latest = project_latest.get(&a.sort_key()).unwrap();
+            let b_latest = project_latest.get(&b.sort_key()).unwrap();
+            b_latest
+                .cmp(a_latest)
+                .then_with(|| a.sort_key().cmp(&b.sort_key()))
+                .then_with(|| b.modified.cmp(&a.modified))
+        });
 
         Ok(sessions)
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -68,22 +68,6 @@ impl SessionInfo {
         format_size(self.size, BINARY)
     }
 
-    /// Return a sort key: filename with optional branch `(...)` stripped,
-    /// so `project(branch)_id` and `project_id` sort together.
-    pub fn sort_key(&self) -> String {
-        let mut result = String::with_capacity(self.filename.len());
-        let mut in_parens = false;
-        for c in self.filename.chars() {
-            match c {
-                '(' => in_parens = true,
-                ')' if in_parens => in_parens = false,
-                _ if !in_parens => result.push(c),
-                _ => {}
-            }
-        }
-        result.to_lowercase()
-    }
-
     /// Format age for display - smart format based on age
     /// - <1 hour: "  45m" (minutes only)
     /// - <1 day:  "   5h" (hours only)
@@ -255,26 +239,8 @@ impl StorageManager {
             }
         }
 
-        // Group by project, ordered by most recent activity per project, newest first within each group
-        // 1. Find the newest modified time per project (sort_key)
-        let mut project_latest: std::collections::HashMap<String, DateTime<Local>> =
-            std::collections::HashMap::new();
-        for s in &sessions {
-            let key = s.sort_key();
-            let entry = project_latest.entry(key).or_insert(s.modified);
-            if s.modified > *entry {
-                *entry = s.modified;
-            }
-        }
-        // 2. Sort: most recently active project first, then newest within each project
-        sessions.sort_by(|a, b| {
-            let a_latest = project_latest.get(&a.sort_key()).unwrap();
-            let b_latest = project_latest.get(&b.sort_key()).unwrap();
-            b_latest
-                .cmp(a_latest)
-                .then_with(|| a.sort_key().cmp(&b.sort_key()))
-                .then_with(|| b.modified.cmp(&a.modified))
-        });
+        // Sort by modification time, newest first
+        sessions.sort_by(|a, b| b.modified.cmp(&a.modified));
 
         Ok(sessions)
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -10,10 +10,10 @@ use std::path::PathBuf;
 use crate::config::Config;
 
 /// Format a timestamp as a smart time prefix:
-/// - Today:      `14:05:30` (H:M:S)
-/// - Yesterday:  `23h`      (hours ago)
-/// - Same year:  `01.02`    (DD.MM)
-/// - Older:      `1y5m`     (years and months ago)
+/// - Today:      `14:05` (H:MM)
+/// - Yesterday:  `23h`   (hours ago)
+/// - Same year:  `01.02` (DD.MM)
+/// - Older:      `1y5m`  (years and months ago)
 pub fn format_smart_time(modified: &DateTime<Local>) -> String {
     let now = Local::now();
     let duration = now.signed_duration_since(*modified);
@@ -21,12 +21,12 @@ pub fn format_smart_time(modified: &DateTime<Local>) -> String {
 
     if duration.num_seconds() < 0 {
         // Future timestamp — just show time
-        return modified.format("%-H:%M:%S").to_string();
+        return modified.format("%H:%M").to_string();
     }
 
     if hours < 24 && now.date_naive() == modified.date_naive() {
-        // Today — show H:M:S
-        modified.format("%-H:%M:%S").to_string()
+        // Today — show H:MM
+        modified.format("%H:%M").to_string()
     } else if hours < 48 {
         // Yesterday — show hours
         format!("{}h", hours)

--- a/src/tui/widgets/file_explorer.rs
+++ b/src/tui/widgets/file_explorer.rs
@@ -917,7 +917,7 @@ impl Widget for FileExplorerWidget<'_> {
 
         // Build list items (collect data first to avoid borrow issues)
         // Note: has_backup and lock_info are cached in FileItem
-        let item_data: Vec<(String, String, String, bool, bool, bool)> = self
+        let item_data: Vec<(String, String, String, String, bool, bool, bool)> = self
             .explorer
             .visible_items()
             .map(|(_, item, is_checked)| {
@@ -925,6 +925,7 @@ impl Widget for FileExplorerWidget<'_> {
                     item.name.clone(),
                     item.agent.clone(),
                     format_size(item.size),
+                    crate::storage::format_smart_time(&item.modified),
                     is_checked,
                     item.has_backup,
                     item.lock_info.is_some(),
@@ -935,38 +936,46 @@ impl Widget for FileExplorerWidget<'_> {
         let show_checkboxes = self.show_checkboxes;
         let items: Vec<ListItem> = item_data
             .iter()
-            .map(|(name, agent, size_str, is_checked, has_bak, is_locked)| {
-                let mut spans = vec![];
-                if show_checkboxes {
-                    let checkbox = if *is_checked { "[x] " } else { "[ ] " };
-                    spans.push(Span::styled(checkbox, theme.text_secondary_style()));
-                }
+            .map(
+                |(name, agent, size_str, time_str, is_checked, has_bak, is_locked)| {
+                    let mut spans = vec![];
+                    if show_checkboxes {
+                        let checkbox = if *is_checked { "[x] " } else { "[ ] " };
+                        spans.push(Span::styled(checkbox, theme.text_secondary_style()));
+                    }
 
-                // Add [opt] indicator prefix if backup exists
-                if *has_bak {
-                    spans.push(Span::styled("[opt] ", theme.accent_style()));
-                }
+                    // Smart time prefix
+                    spans.push(Span::styled(
+                        format!("{:>8}: ", time_str),
+                        theme.text_secondary_style(),
+                    ));
 
-                // Use greyed style for locked (actively recording) files
-                let name_style = if *is_locked {
-                    theme.text_secondary_style()
-                } else {
-                    theme.text_style()
-                };
-                spans.push(Span::styled(name.as_str(), name_style));
+                    // Add [opt] indicator prefix if backup exists
+                    if *has_bak {
+                        spans.push(Span::styled("[opt] ", theme.accent_style()));
+                    }
 
-                // Add recording indicator for locked files
-                if *is_locked {
-                    spans.push(Span::styled(" \u{1F4F9}", theme.text_secondary_style()));
-                }
+                    // Use greyed style for locked (actively recording) files
+                    let name_style = if *is_locked {
+                        theme.text_secondary_style()
+                    } else {
+                        theme.text_style()
+                    };
+                    spans.push(Span::styled(name.as_str(), name_style));
 
-                spans.push(Span::raw("  "));
-                spans.push(Span::styled(
-                    format!("({}, {})", agent, size_str),
-                    theme.text_secondary_style(),
-                ));
-                ListItem::new(Line::from(spans))
-            })
+                    // Add recording indicator for locked files
+                    if *is_locked {
+                        spans.push(Span::styled(" \u{1F4F9}", theme.text_secondary_style()));
+                    }
+
+                    spans.push(Span::raw("  "));
+                    spans.push(Span::styled(
+                        format!("({}, {})", agent, size_str),
+                        theme.text_secondary_style(),
+                    ));
+                    ListItem::new(Line::from(spans))
+                },
+            )
             .collect();
 
         // Get preview data before mutable borrow

--- a/src/tui/widgets/file_explorer.rs
+++ b/src/tui/widgets/file_explorer.rs
@@ -946,7 +946,7 @@ impl Widget for FileExplorerWidget<'_> {
 
                     // Smart time prefix
                     spans.push(Span::styled(
-                        format!("{:>8}: ", time_str),
+                        format!("{:>5}: ", time_str),
                         theme.text_secondary_style(),
                     ));
 

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_basic.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_basic.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 405
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240117-session4.cast  (gemini, 1.0 MB)            ││Name: 20240117-session4.cast          │
-│  [ ] 20240116-session2.cast  (codex, 2.0 MB)             ││Agent: gemini                         │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Size: 1.0 MB                          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Modified: 2024-01-17 16:00            │
+│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
+│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-17 16:00            │
 │                                                          ││Path: /sessions/gemini/20240117-sessio│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_basic.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_basic.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
-│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-17 16:00            │
+│> [ ]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Name: 20240117-session4.cast          │
+│  [ ]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Agent: gemini                         │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Size: 1.0 MB                          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Modified: 2024-01-17 16:00            │
 │                                                          ││Path: /sessions/gemini/20240117-sessio│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_filtered.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_filtered.snap
@@ -3,8 +3,8 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Name: 20240115-session1.cast          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Agent: claude                         │
+│> [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Name: 20240115-session1.cast          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Agent: claude                         │
 │                                                          ││Size: 50.0 KB                         │
 │                                                          ││Modified: 2024-01-15 10:30            │
 │                                                          ││Path: /sessions/claude/20240115-sessio│

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_filtered.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_filtered.snap
@@ -1,11 +1,10 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 439
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Name: 20240115-session1.cast          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Agent: claude                         │
+│> [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Name: 20240115-session1.cast          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Agent: claude                         │
 │                                                          ││Size: 50.0 KB                         │
 │                                                          ││Modified: 2024-01-15 10:30            │
 │                                                          ││Path: /sessions/claude/20240115-sessio│

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_locked_item_preview.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_locked_item_preview.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 944
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240116-recording.cast 📹   (claude, 10.0 KB)       ││Name: 20240116-recording.cast         │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Agent: claude                         │
-│  [ ] 20240114-session3.cast  (codex, 100.0 KB)           ││Size: 10.0 KB                         │
+│> [ ]     2y1m: 20240116-recording.cast 📹   (claude, 10.0 ││Name: 20240116-recording.cast         │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Agent: claude                         │
+│  [ ]     2y1m: 20240114-session3.cast  (codex, 100.0 KB) ││Size: 10.0 KB                         │
 │                                                          ││Duration: 42s                         │
 │                                                          ││Markers: 0                            │
 │                                                          ││Status: 📹  Recording (PID 12345)      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_locked_item_preview.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_locked_item_preview.snap
@@ -3,9 +3,9 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240116-recording.cast 📹   (claude, 10.0 ││Name: 20240116-recording.cast         │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Agent: claude                         │
-│  [ ]     2y1m: 20240114-session3.cast  (codex, 100.0 KB) ││Size: 10.0 KB                         │
+│> [ ]  2y1m: 20240116-recording.cast 📹   (claude, 10.0 KB)││Name: 20240116-recording.cast         │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Agent: claude                         │
+│  [ ]  2y1m: 20240114-session3.cast  (codex, 100.0 KB)    ││Size: 10.0 KB                         │
 │                                                          ││Duration: 42s                         │
 │                                                          ││Markers: 0                            │
 │                                                          ││Status: 📹  Recording (PID 12345)      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_multi_select.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_multi_select.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│  [x]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240115-session1.cast          │
-│  [x]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: claude                         │
-│> [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 50.0 KB                         │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-15 10:30            │
+│  [x]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Name: 20240115-session1.cast          │
+│  [x]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Agent: claude                         │
+│> [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Size: 50.0 KB                         │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Modified: 2024-01-15 10:30            │
 │                                                          ││Path: /sessions/claude/20240115-sessio│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_multi_select.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_multi_select.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 430
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│  [x] 20240117-session4.cast  (gemini, 1.0 MB)            ││Name: 20240115-session1.cast          │
-│  [x] 20240116-session2.cast  (codex, 2.0 MB)             ││Agent: claude                         │
-│> [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Size: 50.0 KB                         │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Modified: 2024-01-15 10:30            │
+│  [x]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240115-session1.cast          │
+│  [x]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: claude                         │
+│> [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 50.0 KB                         │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-15 10:30            │
 │                                                          ││Path: /sessions/claude/20240115-sessio│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_narrow.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_narrow.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ──────────────────────────────────────┐
-│> [ ]     2y1m: 20240117-session4.cast  (gemini,│
-│  [ ]     2y1m: 20240116-session2.cast  (codex, │
-│  [ ]     2y1m: 20240115-session1.cast  (claude,│
-│  [ ]     2y1m: 20240114-session3.cast  (claude,│
+│> [ ]  2y1m: 20240117-session4.cast  (gemini, 1.│
+│  [ ]  2y1m: 20240116-session2.cast  (codex, 2.0│
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50│
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 10│
 │                                                │
 │                                                │
 │                                                │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_narrow.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_narrow.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 470
 expression: output
 ---
 ┌ Sessions ──────────────────────────────────────┐
-│> [ ] 20240117-session4.cast  (gemini, 1.0 MB)  │
-│  [ ] 20240116-session2.cast  (codex, 2.0 MB)   │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB) │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)│
+│> [ ]     2y1m: 20240117-session4.cast  (gemini,│
+│  [ ]     2y1m: 20240116-session2.cast  (codex, │
+│  [ ]     2y1m: 20240115-session1.cast  (claude,│
+│  [ ]     2y1m: 20240114-session3.cast  (claude,│
 │                                                │
 │                                                │
 │                                                │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_with_backup.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_with_backup.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240117-session4.cast  (gemini, 1.0 MB)            ││Name: 20240117-session4.cast          │
-│  [ ] 20240116-session2.cast  (codex, 2.0 MB)             ││Agent: gemini                         │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Size: 1.0 MB                          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Duration: 5m 0s                       │
+│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
+│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Duration: 5m 0s                       │
 │                                                          ││Markers: 2                            │
 │                                                          ││Backup: Available                     │
 │                                                          ││Modified: 2024-01-17 16:00            │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_with_backup.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_with_backup.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
-│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Duration: 5m 0s                       │
+│> [ ]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Name: 20240117-session4.cast          │
+│  [ ]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Agent: gemini                         │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Size: 1.0 MB                          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Duration: 5m 0s                       │
 │                                                          ││Markers: 2                            │
 │                                                          ││Backup: Available                     │
 │                                                          ││Modified: 2024-01-17 16:00            │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_without_backup.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_without_backup.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240117-session4.cast  (gemini, 1.0 MB)            ││Name: 20240117-session4.cast          │
-│  [ ] 20240116-session2.cast  (codex, 2.0 MB)             ││Agent: gemini                         │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Size: 1.0 MB                          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Duration: 5m 0s                       │
+│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
+│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Duration: 5m 0s                       │
 │                                                          ││Markers: 2                            │
 │                                                          ││Modified: 2024-01-17 16:00            │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_without_backup.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_preview_without_backup.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
-│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Duration: 5m 0s                       │
+│> [ ]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Name: 20240117-session4.cast          │
+│  [ ]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Agent: gemini                         │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Size: 1.0 MB                          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Duration: 5m 0s                       │
 │                                                          ││Markers: 2                            │
 │                                                          ││Modified: 2024-01-17 16:00            │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_name.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_name.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 450
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240117-session4.cast  (gemini, 1.0 MB)            ││Name: 20240117-session4.cast          │
-│  [ ] 20240116-session2.cast  (codex, 2.0 MB)             ││Agent: gemini                         │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Size: 1.0 MB                          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Modified: 2024-01-17 16:00            │
+│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
+│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-17 16:00            │
 │                                                          ││Path: /sessions/gemini/20240117-sessio│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_name.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_name.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
-│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-17 16:00            │
+│> [ ]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Name: 20240117-session4.cast          │
+│  [ ]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Agent: gemini                         │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Size: 1.0 MB                          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Modified: 2024-01-17 16:00            │
 │                                                          ││Path: /sessions/gemini/20240117-sessio│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_size.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_size.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 461
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240116-session2.cast  (codex, 2.0 MB)             ││Name: 20240116-session2.cast          │
-│  [ ] 20240117-session4.cast  (gemini, 1.0 MB)            ││Agent: codex                          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Size: 2.0 MB                          │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Modified: 2024-01-16 14:45            │
+│> [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Name: 20240116-session2.cast          │
+│  [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Agent: codex                          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Size: 2.0 MB                          │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Modified: 2024-01-16 14:45            │
 │                                                          ││Path: /sessions/codex/20240116-session│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_size.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_sorted_size.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Name: 20240116-session2.cast          │
-│  [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Agent: codex                          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Size: 2.0 MB                          │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Modified: 2024-01-16 14:45            │
+│> [ ]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Name: 20240116-session2.cast          │
+│  [ ]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Agent: codex                          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Size: 2.0 MB                          │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Modified: 2024-01-16 14:45            │
 │                                                          ││Path: /sessions/codex/20240116-session│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_locked_item.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_locked_item.snap
@@ -3,9 +3,9 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240116-recording.cast 📹   (claude, 10.0 ││Name: 20240116-recording.cast         │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Agent: claude                         │
-│  [ ]     2y1m: 20240114-session3.cast  (codex, 100.0 KB) ││Size: 10.0 KB                         │
+│> [ ]  2y1m: 20240116-recording.cast 📹   (claude, 10.0 KB)││Name: 20240116-recording.cast         │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Agent: claude                         │
+│  [ ]  2y1m: 20240114-session3.cast  (codex, 100.0 KB)    ││Size: 10.0 KB                         │
 │                                                          ││Modified: 2024-01-16 14:00            │
 │                                                          ││Path: /sessions/claude/20240116-record│
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_locked_item.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_locked_item.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 918
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240116-recording.cast 📹   (claude, 10.0 KB)       ││Name: 20240116-recording.cast         │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Agent: claude                         │
-│  [ ] 20240114-session3.cast  (codex, 100.0 KB)           ││Size: 10.0 KB                         │
+│> [ ]     2y1m: 20240116-recording.cast 📹   (claude, 10.0 ││Name: 20240116-recording.cast         │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Agent: claude                         │
+│  [ ]     2y1m: 20240114-session3.cast  (codex, 100.0 KB) ││Size: 10.0 KB                         │
 │                                                          ││Modified: 2024-01-16 14:00            │
 │                                                          ││Path: /sessions/claude/20240116-record│
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_selection.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_selection.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 415
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│  [ ] 20240117-session4.cast  (gemini, 1.0 MB)            ││Name: 20240116-session2.cast          │
-│> [ ] 20240116-session2.cast  (codex, 2.0 MB)             ││Agent: codex                          │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Size: 2.0 MB                          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Modified: 2024-01-16 14:45            │
+│  [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240116-session2.cast          │
+│> [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: codex                          │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 2.0 MB                          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-16 14:45            │
 │                                                          ││Path: /sessions/codex/20240116-session│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_selection.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_selection.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│  [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240116-session2.cast          │
-│> [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: codex                          │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 2.0 MB                          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Modified: 2024-01-16 14:45            │
+│  [ ]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Name: 20240116-session2.cast          │
+│> [ ]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Agent: codex                          │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Size: 2.0 MB                          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Modified: 2024-01-16 14:45            │
 │                                                          ││Path: /sessions/codex/20240116-session│
 │                                                          ││                                      │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_session_preview.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_session_preview.snap
@@ -3,10 +3,10 @@ source: tests/integration/snapshot_tui_test.rs
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
-│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
-│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
-│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Duration: 2m 5s                       │
+│> [ ]  2y1m: 20240117-session4.cast  (gemini, 1.0 MB)     ││Name: 20240117-session4.cast          │
+│  [ ]  2y1m: 20240116-session2.cast  (codex, 2.0 MB)      ││Agent: gemini                         │
+│  [ ]  2y1m: 20240115-session1.cast  (claude, 50.0 KB)    ││Size: 1.0 MB                          │
+│  [ ]  2y1m: 20240114-session3.cast  (claude, 100.0 KB)   ││Duration: 2m 5s                       │
 │                                                          ││Markers: 3                            │
 │                                                          ││Modified: 2024-01-17 16:00            │
 │                                                          ││                                      │

--- a/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_session_preview.snap
+++ b/tests/integration/snapshots/integration__snapshot_tui_test__file_explorer_with_session_preview.snap
@@ -1,13 +1,12 @@
 ---
 source: tests/integration/snapshot_tui_test.rs
-assertion_line: 606
 expression: output
 ---
 ┌ Sessions ────────────────────────────────────────────────┐┌ Preview ─────────────────────────────┐
-│> [ ] 20240117-session4.cast  (gemini, 1.0 MB)            ││Name: 20240117-session4.cast          │
-│  [ ] 20240116-session2.cast  (codex, 2.0 MB)             ││Agent: gemini                         │
-│  [ ] 20240115-session1.cast  (claude, 50.0 KB)           ││Size: 1.0 MB                          │
-│  [ ] 20240114-session3.cast  (claude, 100.0 KB)          ││Duration: 2m 5s                       │
+│> [ ]     2y1m: 20240117-session4.cast  (gemini, 1.0 MB)  ││Name: 20240117-session4.cast          │
+│  [ ]     2y1m: 20240116-session2.cast  (codex, 2.0 MB)   ││Agent: gemini                         │
+│  [ ]     2y1m: 20240115-session1.cast  (claude, 50.0 KB) ││Size: 1.0 MB                          │
+│  [ ]     2y1m: 20240114-session3.cast  (claude, 100.0 KB)││Duration: 2m 5s                       │
 │                                                          ││Markers: 3                            │
 │                                                          ││Modified: 2024-01-17 16:00            │
 │                                                          ││                                      │


### PR DESCRIPTION
## Summary

Improve `agr ls` and `agr cleanup` with a smart time display and simplified sorting.

### Smart time prefix

Each session now shows a contextual timestamp that adapts based on age:

| Age | Format | Example |
|-----|--------|---------|
| Today | `HH:MM` | `14:05` |
| < 48 hours | `Xh` | `23h` |
| Same year | `DD.MM` | `15.01` |
| Older | `XyXm` | `1y2m` |

### Sorting

Sessions are sorted **newest first** — simple chronological order.

### Interactive TUI (`agr ls`)

```
┌ Sessions ──────────────────────────────────────────────┐
│> 14:05: my-project(main)_0tb3aaa.cast  (claude, 1.2 MB)│
│   9:30: my-project_0tb1bbb.cast        (claude, 800 KB)│
│    23h: other-proj_0ta0ccc.cast        (codex, 2.0 MB) │
│  15.01: old-thing_0t50ddd.cast         (claude, 500 KB)│
│   1y2m: ancient_0r11eee.cast           (gemini, 100 KB)│
└────────────────────────────────────────────────────────┘
```

### Text output (`agr ls | cat`)

```
  #  | When  | Agent       | Size       | Filename
-----+-------+-------------+------------+---------------------------
  1  | 14:05 | claude      |    1.2 MiB | my-project(main)_0tb3aaa.cast
  2  |  9:30 | claude      |  800.0 KiB | my-project_0tb1bbb.cast
  3  |   23h | codex       |    2.0 MiB | other-proj_0ta0ccc.cast
  4  | 15.01 | claude      |  500.0 KiB | old-thing_0t50ddd.cast
  5  |  1y2m | gemini      |  100.0 KiB | ancient_0r11eee.cast
```

### Changes
- Add `format_smart_time()` to replace old Age + DateTime columns with a single compact When column
- Simplify sort to pure newest-first (chronological)
- Remove project grouping logic — smart time prefix provides enough context

## Test plan
- [x] Full test suite passes
- [x] TUI snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)