### PR TITLE
feat(tui): add mouse support for list and cleanup

### DIFF
--- a/src/tui/app/mod.rs
+++ b/src/tui/app/mod.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use anyhow::Result;
 use crossterm::{
     cursor::MoveTo,
-    event::{DisableMouseCapture, EnableMouseCapture, KeyEvent},
+    event::{DisableMouseCapture, EnableMouseCapture, KeyEvent, MouseEvent, MouseEventKind},
     execute,
     style::ResetColor,
     terminal::{
@@ -224,6 +224,10 @@ pub trait TuiApp {
     /// Handle a key event. Called from the default `run()` event loop.
     fn handle_key(&mut self, key: KeyEvent) -> Result<()>;
 
+    /// Handle a mouse event. Default implementation provides scroll and click-to-select.
+    /// Override in apps that need checkbox toggle on click (e.g. cleanup).
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> Result<()>;
+
     /// Draw the current UI state. Called from the default `run()` event loop.
     fn draw(&mut self) -> Result<()>;
 
@@ -237,6 +241,7 @@ pub trait TuiApp {
 
             match self.app().next_event()? {
                 Event::Key(key) => self.handle_key(key)?,
+                Event::Mouse(mouse) => self.handle_mouse(mouse)?,
                 Event::Resize(_, _) => {}
                 Event::Tick => {
                     self.shared_state().maybe_refresh_tick();
@@ -249,6 +254,43 @@ pub trait TuiApp {
             }
         }
         Ok(())
+    }
+}
+
+/// Default mouse handler for TUI explorer apps.
+///
+/// Handles scroll wheel (up/down) and left-click to select items.
+/// When `toggle_on_click` is true, clicking also toggles the checkbox (for cleanup).
+pub fn handle_mouse_default(
+    shared: &mut SharedState,
+    terminal_height: u16,
+    mouse: MouseEvent,
+    toggle_on_click: bool,
+) {
+    match mouse.kind {
+        MouseEventKind::ScrollUp => {
+            shared.explorer.up();
+        }
+        MouseEventKind::ScrollDown => {
+            shared.explorer.down();
+        }
+        MouseEventKind::Down(crossterm::event::MouseButton::Left) => {
+            // Map click row to list item index
+            // Layout: row 0 = border, rows 1..n = items inside the list block
+            // Explorer area is full height minus 2 footer rows
+            let explorer_height = terminal_height.saturating_sub(2);
+            // List block has 1-row border top, so items start at row 1
+            let click_row = mouse.row;
+            if click_row >= 1 && click_row < explorer_height.saturating_sub(1) {
+                let item_offset = (click_row - 1) as usize;
+                let scroll_offset = shared.explorer.scroll_offset();
+                let visible_idx = scroll_offset + item_offset;
+                if shared.explorer.select_index(visible_idx) && toggle_on_click {
+                    shared.explorer.toggle_select();
+                }
+            }
+        }
+        _ => {}
     }
 }
 

--- a/src/tui/cleanup_app.rs
+++ b/src/tui/cleanup_app.rs
@@ -6,7 +6,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
 use ratatui::{
     layout::Rect,
     style::{Modifier, Style},
@@ -19,7 +19,9 @@ use super::app::layout::build_explorer_layout;
 use super::app::list_view::render_explorer_list;
 use super::app::modals;
 use super::app::status_footer::{render_footer_text, render_input_line, render_status_line};
-use super::app::{handle_shared_key, App, KeyResult, SharedMode, SharedState, TuiApp};
+use super::app::{
+    handle_mouse_default, handle_shared_key, App, KeyResult, SharedMode, SharedState, TuiApp,
+};
 use super::widgets::preview::prefetch_adjacent_previews;
 use super::widgets::FileItem;
 use crate::config::Config;
@@ -401,6 +403,12 @@ impl TuiApp for CleanupApp {
 
     fn shared_state(&mut self) -> &mut SharedState {
         &mut self.shared
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
+        let (_, height) = self.app.size()?;
+        handle_mouse_default(&mut self.shared, height, mouse, true);
+        Ok(())
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> Result<()> {

--- a/src/tui/event_bus.rs
+++ b/src/tui/event_bus.rs
@@ -3,7 +3,9 @@
 //! Handles keyboard input, resize events, and other terminal events.
 
 use anyhow::Result;
-use crossterm::event::{self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{
+    self, Event as CrosstermEvent, KeyCode, KeyEvent, KeyModifiers, MouseEvent,
+};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
@@ -16,6 +18,8 @@ pub enum Event {
     Resize(u16, u16),
     /// Key was pressed
     Key(KeyEvent),
+    /// Mouse event (click, scroll, etc.)
+    Mouse(MouseEvent),
     /// Tick event for periodic updates
     Tick,
     /// Quit event
@@ -69,6 +73,11 @@ impl EventHandler {
                             }
                             Ok(CrosstermEvent::Resize(width, height)) => {
                                 if tx.send(Event::Resize(width, height)).is_err() {
+                                    break;
+                                }
+                            }
+                            Ok(CrosstermEvent::Mouse(mouse)) => {
+                                if tx.send(Event::Mouse(mouse)).is_err() {
                                     break;
                                 }
                             }

--- a/src/tui/list_app.rs
+++ b/src/tui/list_app.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, MouseEvent};
 use ratatui::{
     layout::{Alignment, Rect},
     style::{Modifier, Style},
@@ -20,7 +20,9 @@ use super::app::layout::build_explorer_layout;
 use super::app::list_view::render_explorer_list;
 use super::app::modals;
 use super::app::status_footer::{render_footer_text, render_input_line, render_status_line};
-use super::app::{handle_shared_key, App, KeyResult, SharedMode, SharedState, TuiApp};
+use super::app::{
+    handle_mouse_default, handle_shared_key, App, KeyResult, SharedMode, SharedState, TuiApp,
+};
 use super::widgets::preview::prefetch_adjacent_previews;
 use super::widgets::FileItem;
 use crate::asciicast::{apply_transforms, TransformResult};
@@ -1069,6 +1071,12 @@ impl TuiApp for ListApp {
 
     fn shared_state(&mut self) -> &mut SharedState {
         &mut self.shared
+    }
+
+    fn handle_mouse(&mut self, mouse: MouseEvent) -> Result<()> {
+        let (_, height) = self.app.size()?;
+        handle_mouse_default(&mut self.shared, height, mouse, false);
+        Ok(())
     }
 
     fn handle_key(&mut self, key: KeyEvent) -> Result<()> {

--- a/src/tui/widgets/file_explorer.rs
+++ b/src/tui/widgets/file_explorer.rs
@@ -460,6 +460,11 @@ impl FileExplorer {
             .unwrap_or(false)
     }
 
+    /// Get the current scroll offset of the list.
+    pub fn scroll_offset(&self) -> usize {
+        self.list_state.offset()
+    }
+
     /// Set the page size for page navigation
     pub fn set_page_size(&mut self, size: usize) {
         self.page_size = size.max(1);
@@ -535,6 +540,18 @@ impl FileExplorer {
         if !self.visible_indices.is_empty() {
             self.selected = self.visible_indices.len() - 1;
             self.sync_list_state();
+        }
+    }
+
+    /// Select a specific visible index (for mouse click).
+    /// Returns true if the index was valid and selection changed.
+    pub fn select_index(&mut self, visible_idx: usize) -> bool {
+        if visible_idx < self.visible_indices.len() {
+            self.selected = visible_idx;
+            self.sync_list_state();
+            true
+        } else {
+            false
         }
     }
 


### PR DESCRIPTION
## Summary
- **Scroll wheel** navigates up/down in `agr ls` and `agr cleanup`
- **Left-click** selects items in `agr ls`
- **Left-click** toggles checkboxes in `agr cleanup`
- Text selection works via **Shift+Click** (standard TUI behavior — mouse capture intercepts normal clicks)
- Player already has text selection since mouse capture is disabled during `suspend()`/`resume()`

### Implementation
- Add `Event::Mouse(MouseEvent)` variant to the event bus (was silently dropped before)
- Add `handle_mouse()` to the `TuiApp` trait
- Add `scroll_offset()` and `select_index()` to `FileExplorer`
- `handle_mouse_default()` shared helper maps click coordinates to list indices

## Test plan
- [x] Full test suite passes
- [ ] Manual: scroll wheel in `agr ls`
- [ ] Manual: click to select in `agr ls`
- [ ] Manual: click checkbox in `agr cleanup`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced mouse event support to the TUI application. Users can now navigate and interact with file explorers and lists using mouse scrolling and click-to-select functionality, offering an intuitive alternative to keyboard-only interaction. This enhancement improves accessibility and provides additional control options for navigating the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->