### PR TITLE
chore(tests): replace [ with [[ in shell conditionals

### DIFF
--- a/tests/e2e/agents.sh
+++ b/tests/e2e/agents.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Check prerequisites when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     check_prerequisites || exit 1
     section "AGR Agent Configuration Tests"
     echo "Test directory: $TEST_DIR"
@@ -88,7 +88,7 @@ else
 fi
 
 # Print summary when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     print_summary
     exit $?
 fi

--- a/tests/e2e/analyzer.sh
+++ b/tests/e2e/analyzer.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Check prerequisites when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     check_prerequisites || exit 1
     section "AGR Analyzer Configuration Tests"
     echo "Test directory: $TEST_DIR"
@@ -69,7 +69,7 @@ agent = "definitely-not-a-real-agent-12345"
 TOMLEOF
 # Config::load() validates agent names — commands should fail gracefully
 OUTPUT=$($AGR config show 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
-if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | /usr/bin/grep -qiE "Unknown agent"; then
+if [[ "$EXIT_CODE" -ne 0 ]] && echo "$OUTPUT" | /usr/bin/grep -qiE "Unknown agent"; then
     pass "Config validation rejects unknown agent name"
 else
     fail "Config should reject unknown agent (exit=$EXIT_CODE): $OUTPUT"
@@ -130,7 +130,7 @@ for AGENT in claude codex gemini; do
     fi
 done
 
-if [ -n "$AVAILABLE_AGENT" ]; then
+if [[ -n "$AVAILABLE_AGENT" ]]; then
     echo "  Using available agent: $AVAILABLE_AGENT"
     # Set up config with auto_analyze enabled
     reset_config
@@ -171,7 +171,7 @@ $AGR record echo -- "quick test" </dev/null 2>&1
 END_TIME=$(date +%s)
 ELAPSED=$((END_TIME - START_TIME))
 # Should complete in under 5 seconds (no analysis overhead)
-if [ "$ELAPSED" -lt 5 ]; then
+if [[ "$ELAPSED" -lt 5 ]]; then
     pass "Recording with auto_analyze=false completes quickly"
 else
     fail "Recording took too long ($ELAPSED seconds), possible unintended analysis"
@@ -197,7 +197,7 @@ fi
 test_header "agr analyze nonexistent.cast fails gracefully"
 reset_config
 OUTPUT=$($AGR analyze /nonexistent/path/to/file.cast 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
-if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | /usr/bin/grep -qiE "not found|no such file"; then
+if [[ "$EXIT_CODE" -ne 0 ]] && echo "$OUTPUT" | /usr/bin/grep -qiE "not found|no such file"; then
     pass "agr analyze fails gracefully with nonexistent file"
 else
     fail "agr analyze should fail with nonexistent file (exit=$EXIT_CODE): $OUTPUT"
@@ -209,9 +209,9 @@ reset_config
 # First create a valid cast file
 $AGR record echo -- "test" </dev/null 2>&1
 CAST_FILE=$(ls "$HOME/recorded_agent_sessions/echo/"*.cast 2>/dev/null | /usr/bin/tail -1)
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     OUTPUT=$($AGR analyze "$CAST_FILE" --agent definitely-not-a-real-agent-12345 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
-    if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | /usr/bin/grep -qi "Unknown agent"; then
+    if [[ "$EXIT_CODE" -ne 0 ]] && echo "$OUTPUT" | /usr/bin/grep -qi "Unknown agent"; then
         pass "agr analyze fails gracefully with unknown agent"
     else
         fail "agr analyze should fail with missing agent (exit=$EXIT_CODE): $OUTPUT"
@@ -233,10 +233,10 @@ TOMLEOF
 # Create a valid cast file if not already present
 $AGR record echo -- "test default agent" </dev/null 2>&1
 CAST_FILE=$(ls "$HOME/recorded_agent_sessions/echo/"*.cast 2>/dev/null | /usr/bin/tail -1)
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     # Fake claude is in PATH, so this should succeed with the configured agent
     OUTPUT=$($AGR analyze "$CAST_FILE" 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
-    if [ "$EXIT_CODE" -eq 0 ] && echo "$OUTPUT" | /usr/bin/grep -qi "marker"; then
+    if [[ "$EXIT_CODE" -eq 0 ]] && echo "$OUTPUT" | /usr/bin/grep -qi "marker"; then
         pass "agr analyze uses config's analysis agent (claude)"
     else
         fail "agr analyze should use config's analysis agent (exit=$EXIT_CODE): $OUTPUT"
@@ -256,10 +256,10 @@ auto_analyze = false
 agent = "claude"
 TOMLEOF
 CAST_FILE=$(ls "$HOME/recorded_agent_sessions/echo/"*.cast 2>/dev/null | /usr/bin/tail -1)
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     OUTPUT=$($AGR analyze "$CAST_FILE" --agent override-agent-test 2>&1) && EXIT_CODE=0 || EXIT_CODE=$?
     # Should fail because override-agent-test is not a supported agent
-    if [ "$EXIT_CODE" -ne 0 ] && echo "$OUTPUT" | /usr/bin/grep -qi "Unknown agent"; then
+    if [[ "$EXIT_CODE" -ne 0 ]] && echo "$OUTPUT" | /usr/bin/grep -qi "Unknown agent"; then
         pass "agr analyze --agent successfully overrides config with unknown agent"
     else
         fail "agr analyze --agent should override config (exit=$EXIT_CODE): $OUTPUT"
@@ -272,7 +272,7 @@ fi
 reset_config
 
 # Print summary when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     print_summary
     exit $?
 fi

--- a/tests/e2e/cleanup.sh
+++ b/tests/e2e/cleanup.sh
@@ -6,14 +6,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Check prerequisites when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     check_prerequisites || exit 1
     section "AGR Cleanup Tests"
     echo "Test directory: $TEST_DIR"
 fi
 
 # Ensure we have at least one recording for cleanup to find
-if [ ! -d "$HOME/recorded_agent_sessions" ] || [ -z "$(ls -A "$HOME/recorded_agent_sessions" 2>/dev/null)" ]; then
+if [[ ! -d "$HOME/recorded_agent_sessions" ]] || [[ -z "$(ls -A "$HOME/recorded_agent_sessions" 2>/dev/null)" ]]; then
     # Create a recording first
     $AGR record echo -- "cleanup test recording" </dev/null
 fi
@@ -31,7 +31,7 @@ else
 fi
 
 # Print summary when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     print_summary
     exit $?
 fi

--- a/tests/e2e/common.sh
+++ b/tests/e2e/common.sh
@@ -3,7 +3,7 @@
 # This file should be sourced by all category test files
 
 # Prevent multiple sourcing
-if [ -n "$_AGR_E2E_COMMON_SOURCED" ]; then
+if [[ -n "$_AGR_E2E_COMMON_SOURCED" ]]; then
     return 0
 fi
 _AGR_E2E_COMMON_SOURCED=1
@@ -26,7 +26,7 @@ fi
 export SHELL_RC
 
 # Test directory setup - create unique per job using PID and random suffix
-if [ -z "$_AGR_TEST_DIR_CREATED" ]; then
+if [[ -z "$_AGR_TEST_DIR_CREATED" ]]; then
     TEST_DIR=$(mktemp -d -t "agr-e2e-$$-XXXXXX")
     ORIGINAL_HOME="$HOME"
     export HOME="$TEST_DIR"
@@ -49,12 +49,12 @@ cleanup() {
 }
 
 # Only set trap if we're the main runner or standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     trap cleanup EXIT
 fi
 
 # Test counters - initialize only if not already set (for main runner aggregation)
-if [ -z "$_AGR_COUNTERS_INITIALIZED" ]; then
+if [[ -z "$_AGR_COUNTERS_INITIALIZED" ]]; then
     PASS=0
     FAIL=0
     _AGR_COUNTERS_INITIALIZED=1
@@ -86,7 +86,7 @@ check_prerequisites() {
         errors=1
     fi
 
-    if [ ! -x "$AGR" ]; then
+    if [[ ! -x "$AGR" ]]; then
         echo "ERROR: AGR binary not found at $AGR"
         echo "Run 'cargo build --release' first"
         errors=1
@@ -173,7 +173,7 @@ print_summary() {
     echo "Failed: $FAIL"
     echo
 
-    if [ $FAIL -gt 0 ]; then
+    if [[ $FAIL -gt 0 ]]; then
         return 1
     fi
     return 0

--- a/tests/e2e/completions.sh
+++ b/tests/e2e/completions.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Check prerequisites when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     check_prerequisites || exit 1
     section "AGR Completions Tests"
     echo "Test directory: $TEST_DIR"
@@ -160,7 +160,7 @@ touch "$BASH_COMP_PATH" "$ZSH_COMP_PATH"
 $AGR shell uninstall 2>&1
 
 # Old completion files should be removed, and RC file should not contain AGR markers
-if [ ! -f "$BASH_COMP_PATH" ] && [ ! -f "$ZSH_COMP_PATH" ] && ! /usr/bin/grep -q "AGR" "$HOME/.zshrc"; then
+if [[ ! -f "$BASH_COMP_PATH" ]] && [[ ! -f "$ZSH_COMP_PATH" ]] && ! /usr/bin/grep -q "AGR" "$HOME/.zshrc"; then
     pass "shell uninstall cleans up old files and RC markers"
 else
     fail "shell uninstall did not clean up properly"
@@ -190,7 +190,7 @@ fi
 $AGR shell uninstall 2>/dev/null || true
 
 # Print summary when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     print_summary
     exit $?
 fi

--- a/tests/e2e/markers.sh
+++ b/tests/e2e/markers.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Check prerequisites when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     check_prerequisites || exit 1
     section "AGR Marker Tests"
     echo "Test directory: $TEST_DIR"
@@ -14,7 +14,7 @@ fi
 
 # Ensure we have a recording to work with
 CAST_FILE=$(ls "$HOME/recorded_agent_sessions/echo/"*.cast 2>/dev/null | /usr/bin/head -1)
-if [ -z "$CAST_FILE" ] || [ ! -f "$CAST_FILE" ]; then
+if [[ -z "$CAST_FILE" ]] || [[ ! -f "$CAST_FILE" ]]; then
     # Create a recording first
     $AGR record echo -- "marker test recording" </dev/null
     CAST_FILE=$(ls "$HOME/recorded_agent_sessions/echo/"*.cast 2>/dev/null | /usr/bin/head -1)
@@ -22,7 +22,7 @@ fi
 
 # Test: Add marker to recording
 test_header "Add marker to recording"
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     $AGR marker add "$CAST_FILE" 0.01 "E2E test marker"
     if /usr/bin/grep -q "E2E test marker" "$CAST_FILE"; then
         pass "Marker added to cast file"
@@ -35,7 +35,7 @@ fi
 
 # Test: List markers shows the marker
 test_header "List markers"
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     MARKERS=$($AGR marker list "$CAST_FILE")
     if echo "$MARKERS" | /usr/bin/grep -q "E2E test marker"; then
         pass "Marker list shows added marker"
@@ -47,7 +47,7 @@ else
 fi
 
 # Print summary when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     print_summary
     exit $?
 fi

--- a/tests/e2e/minify_test.sh
+++ b/tests/e2e/minify_test.sh
@@ -51,7 +51,7 @@ test_debug_output() {
     local compressed=$(cargo run --quiet -- completions --shell-init zsh 2>/dev/null | wc -l)
     local debug=$(cargo run --quiet -- completions --shell-init zsh --debug 2>/dev/null | wc -l)
 
-    if [ "$debug" -gt "$compressed" ]; then
+    if [[ "$debug" -gt "$compressed" ]]; then
         echo "PASS: debug output ($debug lines) > compressed ($compressed lines)"
     else
         echo "FAIL: debug should produce more lines than compressed"
@@ -67,14 +67,14 @@ test_line_counts() {
     echo "Zsh: $zsh_lines lines"
     echo "Bash: $bash_lines lines"
 
-    if [ "$zsh_lines" -le 15 ]; then
+    if [[ "$zsh_lines" -le 15 ]]; then
         echo "PASS: zsh within 15 line target"
     else
         echo "FAIL: zsh exceeds 15 lines"
         exit 1
     fi
 
-    if [ "$bash_lines" -le 15 ]; then
+    if [[ "$bash_lines" -le 15 ]]; then
         echo "PASS: bash within 15 line target"
     else
         echo "FAIL: bash exceeds 15 lines"

--- a/tests/e2e/recording.sh
+++ b/tests/e2e/recording.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Check prerequisites when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     check_prerequisites || exit 1
     section "AGR Recording Tests"
     echo "Test directory: $TEST_DIR"
@@ -18,7 +18,7 @@ fi
 test_header "Record simple command"
 $AGR record echo -- "hello e2e test" </dev/null
 CAST_FILE=$(ls "$HOME/recorded_agent_sessions/echo/"*.cast 2>/dev/null | /usr/bin/head -1)
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     pass "Recording created file"
 else
     fail "Recording did not create file"
@@ -26,7 +26,7 @@ fi
 
 # Test: Verify cast file is valid asciicast v3
 test_header "Verify asciicast v3 format"
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     HEADER=$(/usr/bin/head -1 "$CAST_FILE")
     if echo "$HEADER" | /usr/bin/grep -q '"version":3'; then
         pass "Cast file has version 3 header"
@@ -39,7 +39,7 @@ fi
 
 # Test: Verify output was captured
 test_header "Verify output captured"
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     if /usr/bin/grep -q "hello e2e test" "$CAST_FILE"; then
         pass "Output 'hello e2e test' captured in recording"
     else
@@ -72,7 +72,7 @@ fi
 test_header "Record with different agent"
 $AGR record ls -- -la </dev/null
 LS_CAST=$(ls "$HOME/recorded_agent_sessions/ls/"*.cast 2>/dev/null | /usr/bin/head -1)
-if [ -f "$LS_CAST" ]; then
+if [[ -f "$LS_CAST" ]]; then
     pass "Second recording with different agent created"
 else
     fail "Second recording not created"
@@ -82,7 +82,7 @@ fi
 test_header "Record with --name flag"
 $AGR record echo --name "my-custom-session" -- "test with name flag" </dev/null
 NAMED_CAST="$HOME/recorded_agent_sessions/echo/my-custom-session.cast"
-if [ -f "$NAMED_CAST" ]; then
+if [[ -f "$NAMED_CAST" ]]; then
     pass "Recording with --name flag created correct filename"
 else
     fail "Recording with --name flag did not create expected file"
@@ -110,7 +110,7 @@ fi
 
 # Test: Cast file has proper events structure
 test_header "Cast file event structure"
-if [ -f "$CAST_FILE" ]; then
+if [[ -f "$CAST_FILE" ]]; then
     # Check for output event format [time, "o", "data"]
     if /usr/bin/grep -E '^\[.*"o".*\]' "$CAST_FILE" >/dev/null; then
         pass "Cast file has proper output event structure"
@@ -122,7 +122,7 @@ else
 fi
 
 # Print summary when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     print_summary
     exit $?
 fi

--- a/tests/e2e/shell.sh
+++ b/tests/e2e/shell.sh
@@ -6,7 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Check prerequisites when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     check_prerequisites || exit 1
     section "AGR Shell Integration Tests"
     echo "Test directory: $TEST_DIR"
@@ -47,7 +47,7 @@ fi
 
 # Test: Config.toml created during shell install
 test_header "Config.toml created during shell install"
-if [ -f "$HOME/.config/agr/config.toml" ]; then
+if [[ -f "$HOME/.config/agr/config.toml" ]]; then
     pass "Shell install created config.toml"
 else
     fail "Shell install did not create config.toml"
@@ -161,7 +161,7 @@ test_agr_sh() {
 
         # Source the shell RC file which now contains the embedded AGR script
         RC_FILE="$HOME/$SHELL_RC"
-        if [ -f "$RC_FILE" ]; then
+        if [[ -f "$RC_FILE" ]]; then
             # Use bash to source and run test
             bash -c "source '$RC_FILE'; $test_script"
             return $?
@@ -226,7 +226,7 @@ for AGENT in claude codex gemini; do
     if test_agr_sh "declare -f $AGENT 2>/dev/null | grep -q '_AGR_WRAPPER'"; then
         pass "Wrapper created for default agent: $AGENT"
         # Remember the first agent with a wrapper for later tests
-        if [ -z "$WRAPPER_AGENT_FOUND" ]; then
+        if [[ -z "$WRAPPER_AGENT_FOUND" ]]; then
             WRAPPER_AGENT_FOUND="$AGENT"
         fi
     else
@@ -242,7 +242,7 @@ done
 
 # Test: Wrapper function structure is self-contained (uses first available agent)
 test_header "Wrapper function is self-contained (survives shell snapshots)"
-if [ -n "$WRAPPER_AGENT_FOUND" ]; then
+if [[ -n "$WRAPPER_AGENT_FOUND" ]]; then
     # The wrapper should contain all logic inline, not call external helper functions
     WRAPPER_DEF=$(test_agr_sh "declare -f $WRAPPER_AGENT_FOUND 2>/dev/null")
     # Check for key components that make wrapper self-contained
@@ -302,7 +302,7 @@ run_with_timeout 30 bash -c "
     source \"\$HOME/$SHELL_RC\" && mock-agent test-arg
 " </dev/null
 AFTER_COUNT=$(ls "$HOME/recorded_agent_sessions/mock-agent/"*.cast 2>/dev/null | wc -l | tr -d ' ')
-if [ "$AFTER_COUNT" -gt "$BEFORE_COUNT" ]; then
+if [[ "$AFTER_COUNT" -gt "$BEFORE_COUNT" ]]; then
     pass "Wrapper invoked agr record and created recording"
 else
     fail "Wrapper did not create recording (before=$BEFORE_COUNT, after=$AFTER_COUNT)"
@@ -319,7 +319,7 @@ BEFORE_COUNT=$(ls "$HOME/recorded_agent_sessions/mock-agent/"*.cast 2>/dev/null 
     bash -c "source '$HOME/$SHELL_RC' && mock-agent skip-test" </dev/null 2>/dev/null
 )
 AFTER_COUNT=$(ls "$HOME/recorded_agent_sessions/mock-agent/"*.cast 2>/dev/null | wc -l | tr -d ' ')
-if [ "$AFTER_COUNT" -eq "$BEFORE_COUNT" ]; then
+if [[ "$AFTER_COUNT" -eq "$BEFORE_COUNT" ]]; then
     pass "Wrapper skipped recording when ASCIINEMA_REC is set"
 else
     fail "Wrapper recorded even when ASCIINEMA_REC was set"
@@ -337,7 +337,7 @@ BEFORE_COUNT=$(ls "$HOME/recorded_agent_sessions/mock-agent/"*.cast 2>/dev/null 
     bash -c "source '$HOME/$SHELL_RC' && mock-agent nowrap-test" </dev/null 2>/dev/null
 )
 AFTER_COUNT=$(ls "$HOME/recorded_agent_sessions/mock-agent/"*.cast 2>/dev/null | wc -l | tr -d ' ')
-if [ "$AFTER_COUNT" -eq "$BEFORE_COUNT" ]; then
+if [[ "$AFTER_COUNT" -eq "$BEFORE_COUNT" ]]; then
     pass "Wrapper respects no_wrap list (no recording created)"
 else
     fail "Wrapper ignored no_wrap list and created recording"
@@ -378,7 +378,7 @@ $AGR agents remove test-wrapper-agent 2>/dev/null || true
 $AGR agents remove mock-agent 2>/dev/null || true
 
 # Print summary when running standalone
-if [ -z "$_AGR_E2E_MAIN_RUNNER" ]; then
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
     print_summary
     exit $?
 fi

--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -80,7 +80,7 @@ if grep -q "Error: file exists" "$E2E_LOG" 2>/dev/null; then
     CRITICAL_ERRORS=$((CRITICAL_ERRORS + 1))
 fi
 
-if [ $CRITICAL_ERRORS -gt 0 ]; then
+if [[ $CRITICAL_ERRORS -gt 0 ]]; then
     echo
     echo "Found $CRITICAL_ERRORS critical error(s) that indicate test infrastructure problems."
     FAIL=$((FAIL + CRITICAL_ERRORS))
@@ -93,7 +93,7 @@ echo "Passed: $PASS"
 echo "Failed: $FAIL"
 echo
 
-if [ $FAIL -gt 0 ]; then
+if [[ $FAIL -gt 0 ]]; then
     exit 1
 fi
 echo "All e2e tests passed!"


### PR DESCRIPTION
## Summary
- Replace `[` with `[[` in all 56 SonarCloud-flagged shell conditional tests
- All files use `#!/bin/bash`, so `[[` is fully supported
- Pure mechanical replacement, no logic changes

## Target
- SonarCloud `[[` findings (rule S1035): 56 → 0

## Files changed (10)
`tests/e2e/shell.sh`, `tests/e2e/analyzer.sh`, `tests/e2e/recording.sh`,
`tests/e2e/common.sh`, `tests/e2e/markers.sh`, `tests/e2e/completions.sh`,
`tests/e2e/cleanup.sh`, `tests/e2e/minify_test.sh`, `tests/e2e/agents.sh`,
`tests/e2e_test.sh`

## Test plan
- [x] `cargo build` succeeds
- [x] `bash tests/e2e_test.sh` passes all 80 e2e tests (0 failures)
- [x] `shellcheck` — no new findings introduced
- [ ] SonarCloud quality gate passes
- [ ] SonarCloud `[[` findings = 0
- [ ] CodeRabbit review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Modernized shell test syntax across e2e test suite by updating conditional expressions for improved consistency and reliability.
  * Enhanced diagnostic error messages in marker and recording validation tests for clearer failure feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->