### PR TITLE
fix(tui): fix event loop crash on keypress in ls/cleanup

### DIFF
--- a/src/tui/event_bus.rs
+++ b/src/tui/event_bus.rs
@@ -120,22 +120,15 @@ fn map_crossterm_event(ev: CrosstermEvent, tx: &mpsc::Sender<Event>) -> bool {
             // rename, close dialog, or quit in Normal mode).
             if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
                 let _ = tx.send(Event::Quit);
-                return true;
+                return false;
             }
-            let _ = tx.send(Event::Key(key));
+            tx.send(Event::Key(key)).is_ok()
         }
-        CrosstermEvent::Mouse(mouse) => {
-            let _ = tx.send(Event::Mouse(mouse));
-        }
-        CrosstermEvent::Resize(w, h) => {
-            let _ = tx.send(Event::Resize(w, h));
-        }
-        CrosstermEvent::Paste(text) => {
-            let _ = tx.send(Event::Paste(text));
-        }
-        _ => {}
+        CrosstermEvent::Mouse(mouse) => tx.send(Event::Mouse(mouse)).is_ok(),
+        CrosstermEvent::Resize(w, h) => tx.send(Event::Resize(w, h)).is_ok(),
+        CrosstermEvent::Paste(text) => tx.send(Event::Paste(text)).is_ok(),
+        _ => true,
     }
-    false
 }
 
 /// Reads one crossterm event and dispatches it via `map_crossterm_event`.
@@ -163,33 +156,36 @@ mod tests {
     }
 
     #[test]
-    fn map_crossterm_event_ctrl_c_sends_quit_and_returns_true() {
+    fn map_crossterm_event_ctrl_c_sends_quit_and_returns_false() {
         let (tx, rx) = mpsc::channel();
         let key = crossterm::event::KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
         let result = map_crossterm_event(CrosstermEvent::Key(key), &tx);
-        assert!(result);
+        assert!(
+            !result,
+            "Ctrl+C should return false to break the event loop"
+        );
         assert!(matches!(rx.recv().unwrap(), Event::Quit));
     }
 
     #[test]
-    fn map_crossterm_event_regular_key_sends_key_event() {
+    fn map_crossterm_event_regular_key_sends_key_and_continues() {
         let (tx, rx) = mpsc::channel();
         let key = crossterm::event::KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
         let result = map_crossterm_event(CrosstermEvent::Key(key), &tx);
-        assert!(!result);
+        assert!(result, "Regular key should return true to continue polling");
         assert!(matches!(rx.recv().unwrap(), Event::Key(_)));
     }
 
     #[test]
-    fn map_crossterm_event_resize_sends_resize_event() {
+    fn map_crossterm_event_resize_sends_resize_and_continues() {
         let (tx, rx) = mpsc::channel();
         let result = map_crossterm_event(CrosstermEvent::Resize(120, 40), &tx);
-        assert!(!result);
+        assert!(result, "Resize should return true to continue polling");
         assert!(matches!(rx.recv().unwrap(), Event::Resize(120, 40)));
     }
 
     #[test]
-    fn map_crossterm_event_mouse_sends_mouse_event() {
+    fn map_crossterm_event_mouse_sends_mouse_and_continues() {
         let (tx, rx) = mpsc::channel();
         let mouse = crossterm::event::MouseEvent {
             kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
@@ -198,15 +194,24 @@ mod tests {
             modifiers: KeyModifiers::NONE,
         };
         let result = map_crossterm_event(CrosstermEvent::Mouse(mouse), &tx);
-        assert!(!result);
+        assert!(result, "Mouse event should return true to continue polling");
         assert!(matches!(rx.recv().unwrap(), Event::Mouse(_)));
     }
 
     #[test]
-    fn map_crossterm_event_paste_sends_paste_event() {
+    fn map_crossterm_event_paste_sends_paste_and_continues() {
         let (tx, rx) = mpsc::channel();
         let result = map_crossterm_event(CrosstermEvent::Paste("hello".to_string()), &tx);
-        assert!(!result);
+        assert!(result, "Paste should return true to continue polling");
         assert!(matches!(rx.recv().unwrap(), Event::Paste(ref s) if s == "hello"));
+    }
+
+    #[test]
+    fn map_crossterm_event_returns_false_when_channel_closed() {
+        let (tx, rx) = mpsc::channel::<Event>();
+        drop(rx); // Close the receiving end
+        let key = crossterm::event::KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE);
+        let result = map_crossterm_event(CrosstermEvent::Key(key), &tx);
+        assert!(!result, "Should return false when channel is closed");
     }
 }

--- a/tests/e2e/tui.sh
+++ b/tests/e2e/tui.sh
@@ -40,7 +40,12 @@ fi
 # Usage: run_tui_expect <command> <expect_send_script> [timeout_seconds]
 #
 # Returns the exit code of the spawned process via a temp file (to work with set -e).
-_TUI_EXIT_FILE=$(mktemp)
+# Create temp file inside TEST_DIR so the main runner's cleanup handles it;
+# standalone trap also removes it on early exit.
+_TUI_EXIT_FILE="$TEST_DIR/.tui_exit_code"
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
+    trap 'rm -f "$_TUI_EXIT_FILE"' EXIT
+fi
 run_tui_expect() {
     local cmd="$1"
     local send_script="$2"

--- a/tests/e2e/tui.sh
+++ b/tests/e2e/tui.sh
@@ -61,10 +61,12 @@ run_tui_expect() {
         exit [lindex \$result 3]
     " 2>&1) && echo "0" > "$_TUI_EXIT_FILE" || echo "$?" > "$_TUI_EXIT_FILE"
     echo "$output"
+    return 0
 }
 
 tui_exit_code() {
     cat "$_TUI_EXIT_FILE"
+    return 0
 }
 
 # ============================================

--- a/tests/e2e/tui.sh
+++ b/tests/e2e/tui.sh
@@ -1,0 +1,274 @@
+#!/bin/bash
+# TUI key press tests for AGR
+# Tests that interactive TUI commands (ls, cleanup) handle key presses correctly.
+# Requires: expect (for PTY-based keystroke injection)
+#
+# These tests guard against regressions like the event-loop crash in #146
+# where any keypress caused "Event channel closed: receiving on a closed channel".
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Check prerequisites when running standalone
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
+    check_prerequisites || exit 1
+    section "AGR TUI Key Press Tests"
+    echo "Test directory: $TEST_DIR"
+    create_ci_config
+fi
+
+# Check if expect is available (required for PTY-based TUI testing)
+if ! command -v expect &>/dev/null; then
+    skip "expect not installed — skipping all TUI key press tests"
+    if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
+        print_summary
+        exit $?
+    fi
+    return 0 2>/dev/null || exit 0
+fi
+
+section "TUI Key Press Tests"
+
+# Ensure recordings exist for TUI to display
+EXISTING_CASTS=$(find "$HOME/recorded_agent_sessions" -name "*.cast" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$EXISTING_CASTS" -lt 2 ]]; then
+    $AGR record echo -- "tui test session 1" </dev/null 2>/dev/null || true
+    $AGR record echo -- "tui test session 2" </dev/null 2>/dev/null || true
+fi
+
+# Helper: Run a TUI command via expect, sending keystrokes after startup.
+# Usage: run_tui_expect <command> <expect_send_script> [timeout_seconds]
+#
+# Returns the exit code of the spawned process via a temp file (to work with set -e).
+_TUI_EXIT_FILE=$(mktemp)
+run_tui_expect() {
+    local cmd="$1"
+    local send_script="$2"
+    local timeout_sec="${3:-5}"
+
+    local output
+    output=$(expect -c "
+        log_user 0
+        set timeout $timeout_sec
+        spawn env HOME=$HOME TERM=xterm $cmd
+        sleep 0.5
+        $send_script
+        expect {
+            eof {}
+            timeout { exit 124 }
+        }
+        catch wait result
+        exit [lindex \$result 3]
+    " 2>&1) && echo "0" > "$_TUI_EXIT_FILE" || echo "$?" > "$_TUI_EXIT_FILE"
+    echo "$output"
+}
+
+tui_exit_code() {
+    cat "$_TUI_EXIT_FILE"
+}
+
+# ============================================
+# agr list — key press tests
+# ============================================
+
+# Test: agr list exits cleanly on 'q'
+test_header "agr list exits cleanly on 'q' keypress"
+OUTPUT=$(run_tui_expect "$AGR list" 'send "q"')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr list exits cleanly on 'q'"
+else
+    fail "agr list failed on 'q' (exit=$(tui_exit_code))"
+fi
+
+# Test: agr list handles arrow key navigation without crashing
+test_header "agr list handles arrow keys then 'q'"
+OUTPUT=$(run_tui_expect "$AGR list" '
+    send "\033\[B"
+    sleep 0.1
+    send "\033\[A"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr list handles arrow keys without crashing"
+else
+    fail "agr list crashed on arrow keys (exit=$(tui_exit_code))"
+fi
+
+# Test: agr list handles j/k vim navigation
+test_header "agr list handles j/k navigation then 'q'"
+OUTPUT=$(run_tui_expect "$AGR list" '
+    send "j"
+    sleep 0.1
+    send "k"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr list handles j/k navigation without crashing"
+else
+    fail "agr list crashed on j/k navigation (exit=$(tui_exit_code))"
+fi
+
+# Test: agr list handles search mode (/ then Esc)
+test_header "agr list handles search mode entry and exit"
+OUTPUT=$(run_tui_expect "$AGR list" '
+    send "/"
+    sleep 0.1
+    send "test"
+    sleep 0.1
+    send "\033"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr list handles search mode without crashing"
+else
+    fail "agr list crashed in search mode (exit=$(tui_exit_code))"
+fi
+
+# Test: agr list handles help mode (? to open, q to close help, q to quit)
+test_header "agr list handles help mode"
+OUTPUT=$(run_tui_expect "$AGR list" '
+    send "?"
+    sleep 0.3
+    send "q"
+    sleep 0.2
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr list handles help mode without crashing"
+else
+    fail "agr list crashed in help mode (exit=$(tui_exit_code))"
+fi
+
+# Test: agr list handles Ctrl+C
+test_header "agr list handles Ctrl+C"
+OUTPUT=$(run_tui_expect "$AGR list" 'send "\003"')
+# Ctrl+C may exit with 0 or signal code — the key test is no "Event channel closed" error
+if echo "$OUTPUT" | grep -q "Event channel closed"; then
+    fail "agr list crashed on Ctrl+C with event channel error"
+else
+    pass "agr list handles Ctrl+C without event channel error"
+fi
+
+# Test: agr list handles Escape key
+test_header "agr list handles Escape then 'q'"
+OUTPUT=$(run_tui_expect "$AGR list" '
+    send "\033"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr list handles Escape key without crashing"
+else
+    fail "agr list crashed on Escape (exit=$(tui_exit_code))"
+fi
+
+# Test: agr list handles agent filter mode (f then Esc)
+test_header "agr list handles agent filter mode"
+OUTPUT=$(run_tui_expect "$AGR list" '
+    send "f"
+    sleep 0.3
+    send "\033"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr list handles agent filter mode without crashing"
+else
+    fail "agr list crashed in agent filter mode (exit=$(tui_exit_code))"
+fi
+
+# ============================================
+# agr cleanup — key press tests
+# ============================================
+
+# Test: agr cleanup exits cleanly on 'q'
+test_header "agr cleanup exits cleanly on 'q' keypress"
+OUTPUT=$(run_tui_expect "$AGR cleanup" 'send "q"')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr cleanup exits cleanly on 'q'"
+else
+    fail "agr cleanup failed on 'q' (exit=$(tui_exit_code))"
+fi
+
+# Test: agr cleanup handles arrow keys
+test_header "agr cleanup handles arrow keys then 'q'"
+OUTPUT=$(run_tui_expect "$AGR cleanup" '
+    send "\033\[B"
+    sleep 0.1
+    send "\033\[A"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr cleanup handles arrow keys without crashing"
+else
+    fail "agr cleanup crashed on arrow keys (exit=$(tui_exit_code))"
+fi
+
+# Test: agr cleanup handles space (toggle select) then 'q'
+test_header "agr cleanup handles space toggle then 'q'"
+OUTPUT=$(run_tui_expect "$AGR cleanup" '
+    send " "
+    sleep 0.1
+    send " "
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr cleanup handles space toggle without crashing"
+else
+    fail "agr cleanup crashed on space toggle (exit=$(tui_exit_code))"
+fi
+
+# Test: agr cleanup handles 'a' (select all) then 'q'
+test_header "agr cleanup handles select all then 'q'"
+OUTPUT=$(run_tui_expect "$AGR cleanup" '
+    send "a"
+    sleep 0.1
+    send "a"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr cleanup handles select all without crashing"
+else
+    fail "agr cleanup crashed on select all (exit=$(tui_exit_code))"
+fi
+
+# Test: agr cleanup handles Ctrl+C
+test_header "agr cleanup handles Ctrl+C"
+OUTPUT=$(run_tui_expect "$AGR cleanup" 'send "\003"')
+if echo "$OUTPUT" | grep -q "Event channel closed"; then
+    fail "agr cleanup crashed on Ctrl+C with event channel error"
+else
+    pass "agr cleanup handles Ctrl+C without event channel error"
+fi
+
+# Test: agr cleanup handles search mode
+test_header "agr cleanup handles search mode"
+OUTPUT=$(run_tui_expect "$AGR cleanup" '
+    send "/"
+    sleep 0.1
+    send "test"
+    sleep 0.1
+    send "\033"
+    sleep 0.1
+    send "q"
+')
+if [[ "$(tui_exit_code)" -eq 0 ]]; then
+    pass "agr cleanup handles search mode without crashing"
+else
+    fail "agr cleanup crashed in search mode (exit=$(tui_exit_code))"
+fi
+
+# Clean up
+rm -f "$_TUI_EXIT_FILE"
+
+# Print summary when running standalone
+if [[ -z "$_AGR_E2E_MAIN_RUNNER" ]]; then
+    print_summary
+    exit $?
+fi

--- a/tests/e2e_test.sh
+++ b/tests/e2e_test.sh
@@ -67,6 +67,10 @@ echo
 echo "Running clipboard tests..."
 source "$E2E_DIR/clipboard.sh"
 
+echo
+echo "Running TUI key press tests..."
+source "$E2E_DIR/tui.sh"
+
 # Check for critical errors that should fail the test suite
 # These indicate real problems even if individual tests passed
 echo


### PR DESCRIPTION
## Summary
Fix critical regression from #146 (73693e1) that caused `agr ls` and `agr cleanup` to crash on any keypress with:
```
Error: Event channel closed: receiving on a closed channel
```
Also adds 14 new E2E TUI keypress tests to prevent this class of regression.

## Root Cause

PR #146 refactored `EventHandler::new` to reduce cognitive complexity by extracting `map_crossterm_event()`. During extraction, the boolean return values were **inverted**:

| Event | Before (correct) | After #146 (broken) | This fix |
|-------|------------------|---------------------|----------|
| Normal key/mouse/resize | continue (`true`) | `false` (break!) | `true` (continue) |
| Ctrl+C | break | `true` (continue!) | `false` (break) |
| Channel send error | break | ignored (`let _ =`) | `false` (break) |

**Effect**: The event thread exited on the **first** non-Ctrl+C event, closing the channel. The main TUI loop then tried `recv()` on the closed channel → crash.

**Compounding factor**: The unit tests in #146 asserted the wrong (inverted) values, so the bug passed code review.

## Changes

### Bug fix — `src/tui/event_bus.rs`
1. `map_crossterm_event()` — fix return values: normal events return `true` (continue), Ctrl+C returns `false` (break)
2. Use `tx.send(...).is_ok()` instead of `let _ = tx.send(...)` to detect and break on closed channels
3. Fix all unit test assertions to verify the correct return values
4. Add new test: `map_crossterm_event_returns_false_when_channel_closed`

### E2E TUI keypress tests — `tests/e2e/tui.sh`
14 new tests using `expect` for PTY-based keystroke injection:

**`agr list` (8 tests):** `q` quit, arrow keys, `j`/`k` vim nav, search mode (`/`→type→`Esc`), help mode (`?`→close→quit), `Ctrl+C`, `Escape`, agent filter (`f`→`Esc`)

**`agr cleanup` (6 tests):** `q` quit, arrow keys, space toggle, `a` select-all, `Ctrl+C`, search mode

Gracefully skips when `expect` is not installed.

## Affected Commands
- `agr ls` / `agr list` — TUI session browser
- `agr cleanup` — TUI session cleanup

## Introduced In
- Commit: 73693e1
- PR: #146 — `refactor(tui): reduce cognitive complexity of EventHandler::new`

## Test plan
- [x] `cargo test` — all 7 event_bus unit tests pass (including new channel-closed test)
- [x] `cargo build --release` succeeds
- [x] `bash tests/e2e/tui.sh` — all 14 TUI keypress tests pass
- [x] `bash tests/e2e_test.sh` — full suite passes (94 tests, 0 failures)
- [x] Manual: `agr ls` opens, responds to keypresses, quits cleanly on `q`
- [x] Manual: `agr cleanup` opens, responds to keypresses, quits cleanly on `q`
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved event handling and control flow for Ctrl+C and keyboard input in the terminal interface, preventing event loop interruption.

* **Tests**
  * Added comprehensive end-to-end tests for terminal UI interactions, including navigation, search mode, help system, and keyboard command handling to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->