### PR TITLE
chore(ci): enforce zero new issues on PRs via SonarCloud API

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -32,3 +32,35 @@ jobs:
         timeout-minutes: 5
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Zero new issues check
+        if: github.event_name == 'pull_request'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          echo "Waiting for SonarCloud to finish processing..."
+          sleep 10
+
+          PR_NUMBER=${{ github.event.pull_request.number }}
+          RESPONSE=$(curl -s -u "$SONAR_TOKEN:" \
+            "https://sonarcloud.io/api/issues/search?componentKeys=thiscantbeserious_agent-session-recorder&pullRequest=${PR_NUMBER}&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true&ps=1")
+
+          TOTAL=$(echo "$RESPONSE" | jq -r '.total')
+
+          if [ "$TOTAL" = "null" ] || [ -z "$TOTAL" ]; then
+            echo "::error::Failed to query SonarCloud API"
+            echo "Response: $RESPONSE"
+            exit 1
+          fi
+
+          echo "New issues on PR #${PR_NUMBER}: $TOTAL"
+
+          if [ "$TOTAL" -gt 0 ]; then
+            echo ""
+            echo "::error::SonarCloud found $TOTAL new issue(s) on this PR. All new issues must be resolved before merging."
+            echo ""
+            echo "View issues: https://sonarcloud.io/project/issues?id=thiscantbeserious_agent-session-recorder&pullRequest=${PR_NUMBER}&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true"
+            exit 1
+          fi
+
+          echo "No new issues — clean!"


### PR DESCRIPTION
## Problem

The free plan's built-in "Sonar way" quality gate only checks **ratings** (A–E), not issue counts. Minor code smells that still rate A **pass the gate silently**. Custom quality gates cannot be created on the free plan (`create: false`, `manageConditions: false`).

**Current "Sonar way" conditions (all rating-based):**
| Condition | Threshold | What slips through |
|-----------|-----------|-------------------|
| `new_maintainability_rating` | > A fails | Minor code smells (rating A) pass |
| `new_reliability_rating` | > A fails | — |
| `new_security_rating` | > A fails | — |

## Solution

Add a **zero new issues check** step after the quality gate that queries the SonarCloud API directly:

```
GET /api/issues/search?pullRequest={PR}&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true
```

If `total > 0`, CI fails with a link to the issues page. This enforces a strict **zero new issues** policy regardless of severity rating.

## How enforcement works (3 layers)

| Layer | Check | Catches |
|-------|-------|---------|
| 1 | **SonarCloud Quality Gate** (`sonarqube-quality-gate-action`) | Major issues (rating > A), coverage, duplication |
| 2 | **Zero new issues** (API query, this PR) | **Every** new issue including minor code smells |
| 3 | **Required status checks** (branch protection) | Blocks merge until layers 1+2 pass |

## Test plan
- [x] CI runs the new "Zero new issues check" step on this PR
- [x] Step passes (this PR introduces 0 code issues)
- [ ] Verify on a future PR that introduces an issue: CI fails with link to SonarCloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)