### PR TITLE
chore(ci): rename SonarCloud job to Check & Gate

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   sonarcloud:
-    name: SonarCloud
+    name: Check & Gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Rename the SonarCloud workflow job from `SonarCloud` to `Check & Gate` to avoid redundant `SonarCloud / SonarCloud` display in PR checks
- PR checks now clearly distinguish between:
  - `SonarCloud / Check & Gate` — our workflow job (scan, quality gate, zero new issues enforcement)
  - `SonarCloud Code Analysis` — the external SonarCloud check
- Updated the required status check in the branch protection ruleset accordingly

## Files changed (1)
`.github/workflows/sonarcloud.yml`

## Test plan
- [ ] CI passes (the renamed job runs successfully)
- [ ] PR checks display as `SonarCloud / Check & Gate`
- [ ] Required status check enforces the new name

🤖 Generated with [Claude Code](https://claude.com/claude-code)