### PR TITLE
fix(storage): show actual oldest session in status stats

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -453,7 +453,7 @@ impl StorageManager {
             *sessions_by_agent.entry(session.agent.clone()).or_insert(0) += 1;
         }
 
-        let oldest_session = sessions.first().cloned();
+        let oldest_session = sessions.last().cloned();
 
         // Calculate disk percentage (simplified - uses available space)
         let disk_percentage = self.calculate_disk_percentage(total_size);

--- a/tests/integration/storage_test.rs
+++ b/tests/integration/storage_test.rs
@@ -942,3 +942,28 @@ fn resolve_filename_conflict_with_existing() {
     let third = manager.import_cast_file(&source, "claude").unwrap();
     assert!(third.to_string_lossy().contains("conflict-2.cast"));
 }
+
+#[test]
+fn stats_oldest_session_is_actually_oldest() {
+    let temp = TempDir::new().unwrap();
+    let config = create_test_config(&temp);
+
+    // Create the "old" session first
+    create_test_session(temp.path(), "claude", "old.cast", "old");
+
+    // Sleep briefly so filesystem mtime differs
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Create the "new" session second (guaranteed newer mtime)
+    create_test_session(temp.path(), "claude", "new.cast", "new");
+
+    let manager = StorageManager::new(config);
+    let stats = manager.get_stats().unwrap();
+    let oldest = stats.oldest_session.expect("should have oldest session");
+
+    assert_eq!(
+        oldest.filename, "old.cast",
+        "oldest should be old.cast, got {}",
+        oldest.filename
+    );
+}

--- a/tests/integration/storage_test.rs
+++ b/tests/integration/storage_test.rs
@@ -951,8 +951,8 @@ fn stats_oldest_session_is_actually_oldest() {
     // Create the "old" session first
     create_test_session(temp.path(), "claude", "old.cast", "old");
 
-    // Sleep briefly so filesystem mtime differs
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    // Sleep to ensure distinguishable mtime on filesystems with 1s granularity
+    std::thread::sleep(std::time::Duration::from_millis(1100));
 
     // Create the "new" session second (guaranteed newer mtime)
     create_test_session(temp.path(), "claude", "new.cast", "new");


### PR DESCRIPTION
## Summary
- `get_stats()` used `sessions.first()` which returns the **newest** session (list is sorted newest-first), causing `agr status` to show wrong "Oldest" date
- Changed to `sessions.last()` to correctly return the oldest session
- Added regression test `stats_oldest_session_is_actually_oldest`

## Test plan
- [x] `cargo test stats_oldest_session_is_actually_oldest` passes
- [x] Full test suite passes
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect identification of the oldest session in storage statistics. The oldest session is now accurately determined from the sorted session list, ensuring accurate session age reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->